### PR TITLE
Fix SRT timestamp rounding and prevent concurrent transcriptions

### DIFF
--- a/parakeet_transcribe.py
+++ b/parakeet_transcribe.py
@@ -25,30 +25,7 @@ import torch
 import gc
 from torch.cuda.amp import autocast
 
-# --- SRT Formatting Function ---
-def format_time_srt(seconds: float) -> str:
-    """
-    Formats a duration in seconds into the SRT (SubRip Text) time format.
-
-    The format is HH:MM:SS,mmm (hours, minutes, seconds, milliseconds).
-    If the input is not a valid number or is negative, it defaults to 0.0 seconds.
-
-    Args:
-        seconds (float): The time in seconds to format.
-
-    Returns:
-        str: The time formatted as an SRT timestamp string (e.g., "00:01:23,456").
-    """
-    if not isinstance(seconds, (int, float)):
-        seconds = 0.0 # Default to 0 if input is not a number
-    if seconds < 0:
-        seconds = 0.0 # Treat negative times as 0
-    total_seconds_int = int(seconds)
-    milliseconds = int(round((seconds - total_seconds_int) * 1000))
-    hours = total_seconds_int // 3600
-    minutes = (total_seconds_int % 3600) // 60
-    secs = total_seconds_int % 60
-    return f"{hours:02}:{minutes:02}:{secs:02},{milliseconds:03}"
+from srt_utils import format_time_srt
 
 def generate_srt_from_processed_timestamps(all_processed_timestamps: list, srt_file_path: str, timestamp_type: str = "segment"):
     """

--- a/srt_utils.py
+++ b/srt_utils.py
@@ -1,0 +1,19 @@
+def format_time_srt(seconds: float) -> str:
+    """Convert seconds to SRT timestamp format HH:MM:SS,mmm.
+
+    Values outside valid ranges are clamped to zero. Rounding that pushes
+    milliseconds to 1000 correctly carries over to the seconds component.
+    """
+    if not isinstance(seconds, (int, float)):
+        seconds = 0.0
+    if seconds < 0:
+        seconds = 0.0
+    total_seconds_int = int(seconds)
+    milliseconds = int(round((seconds - total_seconds_int) * 1000))
+    if milliseconds >= 1000:
+        total_seconds_int += 1
+        milliseconds -= 1000
+    hours = total_seconds_int // 3600
+    minutes = (total_seconds_int % 3600) // 60
+    secs = total_seconds_int % 60
+    return f"{hours:02}:{minutes:02}:{secs:02},{milliseconds:03}"

--- a/tests/test_format_time_srt.py
+++ b/tests/test_format_time_srt.py
@@ -1,0 +1,16 @@
+import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from srt_utils import format_time_srt
+
+class TestFormatTimeSrt(unittest.TestCase):
+    def test_rounding_carries_seconds(self):
+        self.assertEqual(format_time_srt(1.9996), "00:00:02,000")
+    def test_negative_value_clamped(self):
+        self.assertEqual(format_time_srt(-5.0), "00:00:00,000")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle millisecond rounding overflow when formatting SRT timestamps
- centralize timestamp formatter in new `srt_utils` module
- add unit tests for SRT formatting edge cases
- prevent concurrent transcription runs in mpv scripts to avoid multiple Python instances

## Testing
- `python -m py_compile $(git ls-files '*.py') && python tests/test_format_time_srt.py`