### PR TITLE
Clamp non-finite timestamps in SRT formatter

### DIFF
--- a/srt_utils.py
+++ b/srt_utils.py
@@ -1,10 +1,14 @@
-def format_time_srt(seconds: float) -> str:
-    """Convert seconds to SRT timestamp format HH:MM:SS,mmm.
+import math
 
-    Values outside valid ranges are clamped to zero. Rounding that pushes
-    milliseconds to 1000 correctly carries over to the seconds component.
+
+def format_time_srt(seconds: float) -> str:
+    """Convert seconds to SRT timestamp format ``HH:MM:SS,mmm``.
+
+    Any non-numeric, negative, or non-finite (``NaN``/``inf``) values are
+    clamped to zero. Rounding that pushes milliseconds to 1000 correctly
+    carries over to the seconds component.
     """
-    if not isinstance(seconds, (int, float)):
+    if not isinstance(seconds, (int, float)) or not math.isfinite(seconds):
         seconds = 0.0
     if seconds < 0:
         seconds = 0.0

--- a/tests/test_format_time_srt.py
+++ b/tests/test_format_time_srt.py
@@ -11,6 +11,10 @@ class TestFormatTimeSrt(unittest.TestCase):
         self.assertEqual(format_time_srt(1.9996), "00:00:02,000")
     def test_negative_value_clamped(self):
         self.assertEqual(format_time_srt(-5.0), "00:00:00,000")
+    def test_nan_value_clamped(self):
+        self.assertEqual(format_time_srt(float('nan')), "00:00:00,000")
+    def test_infinite_value_clamped(self):
+        self.assertEqual(format_time_srt(float('inf')), "00:00:00,000")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure `format_time_srt` safely handles NaN and infinite inputs by clamping to zero
- add tests for NaN and infinite values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4315c7e98832c8f3d8f8f58f51f1b