### PR TITLE
Use soxr float32 extraction and forward segmenter args

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Automatically generate subtitles for media playing in MPV using NVIDIA's Parakee
     * **FFmpeg Pre-processing Mode (`Alt+6`):** Applies FFmpeg audio filters (e.g., for normalization/denoising) to the extracted audio before transcription with default Python precision.
     * **FFmpeg Pre-processing + Python Float32 Mode (`Alt+7`):** Combines FFmpeg audio filtering with float32 precision in Python.
 * **Customizable:** Configure paths, keybindings, and FFmpeg filters.
+* **High-quality audio extraction:** Uses FFmpeg's `soxr` resampler with float32 output for 16 kHz mono, reducing resample hops and avoiding extra quantization.
 * **Immediate SRT Loading:** Subtitles are loaded as soon as transcription is complete.
 * **Temporary File Management:** Handles temporary audio files, cleaning them up when MPV is closed.
 
@@ -169,7 +170,7 @@ Notes:
 
 Quality notes:
 
-* Fewer resampling hops plus FFmpeg's high-quality `soxr` resampler preserve consonants and reduce word-error rate.
+* A single high-quality resample with FFmpeg's `soxr` resampler and float32 output preserves consonants and reduces word-error rate.
 
 Troubleshooting:
 

--- a/parakeet_caption_for_JellyfinMpvShim.lua
+++ b/parakeet_caption_for_JellyfinMpvShim.lua
@@ -392,8 +392,14 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
     log("info", "Step 1.1: Extracting audio track with FFmpeg...")
     log("info", "Outputting raw temporary audio to: ", temp_audio_raw_path)
 
-    -- Common FFmpeg args: no video, PCM 16-bit little-endian audio, 16kHz sample rate, 1 channel (mono), overwrite output
-    local ffmpeg_common_args = {"-vn", "-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1", "-y"}
+    -- Common FFmpeg args: no video, 16 kHz mono via soxr resampler, float32 output, overwrite file
+    local ffmpeg_common_args = {
+        "-vn",
+        "-ac", "1",
+        "-af", "aresample=16000:resampler=soxr:precision=28",
+        "-c:a", "pcm_f32le",
+        "-y"
+    }
     local ffmpeg_args_extract
     local ffmpeg_map_value_for_log -- For logging which -map option was used
 
@@ -473,12 +479,19 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
         end
         log("info", "Step 1.5: Applying FFmpeg audio filters: ", ffmpeg_audio_filters)
         mp.osd_message("Parakeet: Applying FFmpeg audio filters...", 5)
+        local filter_chain = ffmpeg_audio_filters
+        if filter_chain ~= "" then
+            filter_chain = filter_chain .. ",aresample=16000:resampler=soxr:precision=28"
+        else
+            filter_chain = "aresample=16000:resampler=soxr:precision=28"
+        end
         local ffmpeg_args_filter = {
             ffmpeg_path,
             "-i", temp_audio_raw_path,
-            "-af", ffmpeg_audio_filters,
-            "-ar", "16000", -- Ensure sample rate is maintained for the ASR model
-            "-y",           -- Overwrite output file if it exists
+            "-af", filter_chain,
+            "-ac", "1",
+            "-c:a", "pcm_f32le",
+            "-y",
             temp_audio_for_python
         }
         log("debug", "Running FFmpeg filter pass: ", table.concat(ffmpeg_args_filter, " "))
@@ -513,6 +526,8 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
     if force_python_float32_flag then
         table.insert(python_command_args, "--force_float32")
     end
+
+    for _, v in ipairs(seg_args) do table.insert(python_command_args, v) end
 
     log("debug", "Running Python script: ", table.concat(python_command_args, " "))
     local python_res = utils.subprocess({ args = python_command_args, cancellable = false, capture_stdout = true, capture_stderr = true })


### PR DESCRIPTION
## Summary
- resample FFmpeg extraction with soxr and float32 to avoid extra quantization
- mirror soxr+float32 chain in FFmpeg preprocessing modes
- pass word segmenter args into standard transcription paths

## Testing
- `pytest`
- `luac -p parakeet_caption.lua parakeet_caption_for_JellyfinMpvShim.lua`


------
https://chatgpt.com/codex/tasks/task_b_68c02b152de4832c93c2c3de60007336