### PR TITLE
Ensure vocal separation runs in float32

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,7 @@ Download the YAML + CKPT from the pcunwa Hugging Face repositories, for example:
 Change presets by editing `roformer_preset_fast` or `roformer_preset_slow` in `parakeet_caption.lua`,
 or by passing `--preset` to `python separation/bsr_separate.py`.
 
-FP16 for separation is now opt-in. Toggle `separator_use_fp16` in the Lua script or pass `--fp16` to `bsr_separate.py` if you
-need the extra speed or lower VRAM usage.
+Separation runs in float32 for best quality. Model weights remain in fp32 and autocast is disabled.
 
 Notes:
 
@@ -174,7 +173,7 @@ Quality notes:
 
 Troubleshooting:
 
-* CUDA OOM → increase chunk size, reduce overlap, or enable `--fp16` to save VRAM.
+* CUDA OOM → increase chunk size or reduce overlap to save VRAM.
 
 ## Python Transcription Script (`parakeet_transcribe.py`)
 

--- a/parakeet_caption.lua
+++ b/parakeet_caption.lua
@@ -666,7 +666,6 @@ local function run_isolate_then_asr(model)
         "--out_wav", temp_vocals_44k,
         "--cfg", model.cfg, "--ckpt", model.ckpt, "--target", model.target,
         "--device", "cuda",
-        "--fp16",
         "--save_sr", "44100",
         "--channels", "2"
     }

--- a/separation/bsr_separate.py
+++ b/separation/bsr_separate.py
@@ -17,6 +17,7 @@ import soundfile as sf
 import torch
 import librosa
 torch.backends.cudnn.benchmark = True
+torch.set_default_dtype(torch.float32)
 
 # Allow execution without manipulating the environment. When launched
 # directly (e.g., via `python separation/bsr_separate.py`), ensure the
@@ -36,7 +37,6 @@ def main() -> int:
     parser.add_argument("--ckpt", required=True, help="Path to model checkpoint")
     parser.add_argument("--target", default="vocals", help="Target stem to extract")
     parser.add_argument("--device", default="cuda", help="Device to run on (cuda/cpu)")
-    parser.add_argument("--fp16", action="store_true")
     parser.add_argument("--save_sr", type=int, help="Optional output sample rate (default: mixture SR)")
     parser.add_argument("--channels", type=int, choices=[1, 2], help="Optional output channels (default: mixture channels)")
     args = parser.parse_args()
@@ -47,7 +47,7 @@ def main() -> int:
     device = args.device
     if device == "cuda" and not torch.cuda.is_available():
         raise RuntimeError("CUDA requested but not available")
-    sep = load_separator(str(args.cfg), str(args.ckpt), device=device, fp16=args.fp16)
+    sep = load_separator(str(args.cfg), str(args.ckpt), device=device)
     sep.model.to(device)
     sep.model.eval()
 


### PR DESCRIPTION
## Summary
- run RoFormer separator strictly in float32 with default dtype set
- remove fp16 path and autocast, keeping model weights in fp32
- update mpv Lua script and docs to reflect float32 extraction and separation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c03aea6e00832c902e69b734f6c1b6