### PR TITLE
Pack consecutive subtitles into two-line blocks

### DIFF
--- a/parakeet_transcribe.py
+++ b/parakeet_transcribe.py
@@ -194,18 +194,22 @@ def main():
     parser.add_argument("--max_duration", type=float, default=6.0, help="Maximum subtitle duration in seconds for word segmentation")
     parser.add_argument("--pause", type=float, default=0.6, help="Inter-word pause (s) that triggers a new subtitle when using word segmentation")
     parser.add_argument("--fps", type=float, default=24.0, help="Video FPS for frame snapping")
-    parser.add_argument("--max_chars_per_line", type=int, default=46)
-    parser.add_argument("--pause_ms", type=int, default=220, help="Minimum inter-word silence to open a split candidate")
+    parser.add_argument("--max_chars_per_line", type=int, default=40)
+    parser.add_argument("--pause_ms", type=int, default=240, help="Minimum inter-word silence to open a split candidate")
+    parser.add_argument("--punct_pause_ms", type=int, default=160,
+                        help="Pause after sentence-ending punctuation to allow a split")
+    parser.add_argument("--comma_pause_ms", type=int, default=120,
+                        help="Pause after commas to allow a split")
     parser.add_argument("--cps", type=float, default=20.0, help="Target characters-per-second reading speed")
     parser.add_argument("--no_spacy", action="store_true", help="Disable spaCy hints even if available")
-    parser.add_argument("--coalesce_gap_ms", type=int, default=300,
+    parser.add_argument("--coalesce_gap_ms", type=int, default=360,
                         help="Merge consecutive events if gap ≤ this and 2-line fit/cps ok")
-    parser.add_argument("--two_line_threshold", type=float, default=0.60,
+    parser.add_argument("--two_line_threshold", type=float, default=0.55,
                         help="Prefer 2 lines once block length ≥ this fraction of a line")
     parser.add_argument(
         "--min_readable_ms",
         type=int,
-        default=900,
+        default=1100,
         help="Soft minimum on-screen time per cue; short cues extend/merge",
     )
     args = parser.parse_args()
@@ -221,6 +225,8 @@ def main():
     fps = args.fps
     max_chars_per_line = args.max_chars_per_line
     pause_ms = args.pause_ms
+    punct_pause_ms = args.punct_pause_ms
+    comma_pause_ms = args.comma_pause_ms
     cps = args.cps
     use_spacy = not args.no_spacy
     min_readable = args.min_readable_ms / 1000.0
@@ -422,6 +428,8 @@ def main():
             max_chars_per_line=max_chars_per_line,
             max_lines=2,
             pause_ms=pause_ms,
+            punct_pause_ms=punct_pause_ms,
+            comma_pause_ms=comma_pause_ms,
             cps_target=cps,
             snap_fps=fps,
             use_spacy=use_spacy,

--- a/segmenter.py
+++ b/segmenter.py
@@ -76,7 +76,7 @@ def shape_words_into_two_lines_balanced(
     words,
     max_chars,
     prefer_two_lines: bool = True,
-    two_line_threshold: float = 0.72,
+    two_line_threshold: float = 0.55,
 ):
     """
     Input: list of word dicts with 'word','start','end'
@@ -177,15 +177,15 @@ def coalesce_short_neighbors(
 
 def segment_by_pause_and_phrase(
     words: List[Dict[str, Any]],
-    max_chars_per_line: int = 46,
+    max_chars_per_line: int = 40,
     max_lines: int = 2,
-    pause_ms: int = 220,
+    pause_ms: int = 240,
     punct_pause_ms: int = 160,
     comma_pause_ms: int = 120,
     cps_target: float = 20.0,
     use_spacy: bool = True,
     spacy_model: str = "en_core_web_sm",
-    two_line_threshold: float = 0.70,
+    two_line_threshold: float = 0.55,
 ) -> List[Dict[str, Any]]:
     """
     Build segments from ASR word-level tokens using pauses as the primary cue.

--- a/srt_utils.py
+++ b/srt_utils.py
@@ -23,8 +23,8 @@ def pack_into_two_line_blocks(
     events: List[Dict[str, Any]],
     max_chars_per_line: int = 40,
     cps_target: float = 20.0,
-    coalesce_gap_ms: int = 300,
-    two_line_threshold: float = 0.60,
+    coalesce_gap_ms: int = 360,
+    two_line_threshold: float = 0.55,
 ) -> List[Dict[str, Any]]:
     """Greedily merge consecutive events into a single 2-line block when:
       - the inter-event gap ≤ coalesce_gap_ms
@@ -50,7 +50,7 @@ def pack_into_two_line_blocks(
 
             nxt_words = events[j + 1].get("words") or []
             cand_words = blk_words + nxt_words
-            lines, used_words, overflow = shape_words_into_two_lines_balanced(
+            lines, _, overflow = shape_words_into_two_lines_balanced(
                 cand_words,
                 max_chars_per_line,
                 prefer_two_lines=True,
@@ -69,7 +69,7 @@ def pack_into_two_line_blocks(
             end = cand_end
             j += 1
 
-        lines, used_words, overflow = shape_words_into_two_lines_balanced(
+        lines, _, overflow = shape_words_into_two_lines_balanced(
             blk_words,
             max_chars_per_line,
             prefer_two_lines=True,
@@ -153,10 +153,10 @@ def _smart_join(a: str, b: str) -> str:
 
 def enforce_min_readable(
     events: list[dict],
-    min_dur: float = 0.90,
+    min_dur: float = 1.10,
     max_dur: float = 7.0,
     reflow: bool = True,
-    max_chars_per_line: int = 46,
+    max_chars_per_line: int = 40,
 ):
     """Extend or merge very short cues so they remain readable."""
     i = 0
@@ -212,15 +212,17 @@ def enforce_min_readable(
 
 def postprocess_segments(
     segments: List[Dict[str, Any]],
-    max_chars_per_line: int = 46,
+    max_chars_per_line: int = 40,
     max_lines: int = 2,
-    pause_ms: int = 220,
+    pause_ms: int = 240,
+    punct_pause_ms: int = 160,
+    comma_pause_ms: int = 120,
     cps_target: float = 20.0,
     snap_fps: float | None = None,
     use_spacy: bool = True,
-    min_readable: float = 0.9,
-    coalesce_gap_ms: int = 300,
-    two_line_threshold: float = 0.60,
+    min_readable: float = 1.1,
+    coalesce_gap_ms: int = 360,
+    two_line_threshold: float = 0.55,
 ) -> List[Dict[str, Any]]:
     """Segment words by pauses and phrases, shape lines, and quantize to frames."""
     # flatten word list (Parakeet provides accurate word timestamps)
@@ -240,6 +242,8 @@ def postprocess_segments(
         max_chars_per_line=max_chars_per_line,
         max_lines=max_lines,
         pause_ms=pause_ms,
+        punct_pause_ms=punct_pause_ms,
+        comma_pause_ms=comma_pause_ms,
         cps_target=cps_target,
         use_spacy=use_spacy,
         two_line_threshold=two_line_threshold,


### PR DESCRIPTION
## Summary
- add `pack_into_two_line_blocks` to merge short neighboring cues without losing timing
- wire new 2-line packing into subtitle post-processing pipeline
- expose `--coalesce_gap_ms` and `--two_line_threshold` CLI knobs for finer control

## Testing
- `pytest -q`
