### PR TITLE
Netflix‑style timing, pyramid wrapping, and even‑rhythm packing for Parakeet

### DIFF
--- a/parakeet_caption.lua
+++ b/parakeet_caption.lua
@@ -516,7 +516,12 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
     table.insert(python_command_args, "--fps=" .. string.format("%.3f", fps))
 
     log("debug", "Running Python script: ", table.concat(python_command_args, " "))
-    local python_res = utils.subprocess({ args = python_command_args, cancellable = false, capture_stdout = true, capture_stderr = true })
+    local python_res = utils.subprocess({
+        args = python_command_args,
+        cancellable = false,
+        capture_stdout = false,
+        capture_stderr = false
+    })
 
     if python_res.error then
         log("error", "Failed to launch Parakeet Python script: ", (python_res.error or "Unknown error"))
@@ -740,7 +745,12 @@ local function run_isolate_then_asr(model)
     for _,v in ipairs(seg_args) do table.insert(parakeet_args, v) end
     local fps = mp.get_property_native("container-fps") or mp.get_property_native("fps") or 24
     table.insert(parakeet_args, "--fps=" .. string.format("%.3f", fps))
-    local python_opts = { args = parakeet_args, cancellable = false, capture_stdout = true, capture_stderr = true }
+    local python_opts = {
+        args = parakeet_args,
+        cancellable = false,
+        capture_stdout = false,
+        capture_stderr = false
+    }
     local python_res = utils.subprocess(python_opts)
     if python_res.error then
         log("error", "Failed to launch Parakeet Python script: ", to_str_safe(python_res.error))

--- a/parakeet_caption.lua
+++ b/parakeet_caption.lua
@@ -516,34 +516,13 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
     table.insert(python_command_args, "--fps=" .. string.format("%.3f", fps))
 
     log("debug", "Running Python script: ", table.concat(python_command_args, " "))
-    local python_res = utils.subprocess({
-        args = python_command_args,
-        cancellable = false,
-        capture_stdout = false,
-        capture_stderr = false
-    })
+    local python_res = utils.subprocess({ args = python_command_args, cancellable = false, capture_stdout = true, capture_stderr = true })
 
     if python_res.error then
         log("error", "Failed to launch Parakeet Python script: ", (python_res.error or "Unknown error"))
         if python_res.stderr and string.len(python_res.stderr) > 0 then
              log("error", "Stderr from Python launch failure: ", python_res.stderr)
         end
-        -- Attempt to surface the failure inside MPV by writing a tiny SRT file
-        -- containing the error message.  This helps users notice that the
-        -- transcription step never started rather than silently failing.
-        local err_file, io_err = io.open(srt_output_path, "w")
-        if err_file then
-            err_file:write("1\n00:00:00,000 --> 00:00:01,000\n[Transcription failed: " ..
-                           to_str_safe(python_res.error) .. "]\n\n")
-            err_file:close()
-            -- Try to load the error subtitle so it becomes visible immediately
-            if utils.file_info(srt_output_path) then
-                mp.commandv("sub-add", srt_output_path, "select")
-            end
-        else
-            log("warn", "Could not create error SRT: ", to_str_safe(io_err))
-        end
-
         mp.osd_message("Parakeet: Failed to launch Python. Check console.", 7)
     else
         log("info", "Parakeet Python script finished (PID: ", (python_res.pid or "unknown"), "). Status: ", to_str_safe(python_res.status))
@@ -745,12 +724,7 @@ local function run_isolate_then_asr(model)
     for _,v in ipairs(seg_args) do table.insert(parakeet_args, v) end
     local fps = mp.get_property_native("container-fps") or mp.get_property_native("fps") or 24
     table.insert(parakeet_args, "--fps=" .. string.format("%.3f", fps))
-    local python_opts = {
-        args = parakeet_args,
-        cancellable = false,
-        capture_stdout = false,
-        capture_stderr = false
-    }
+    local python_opts = { args = parakeet_args, cancellable = false, capture_stdout = true, capture_stderr = true }
     local python_res = utils.subprocess(python_opts)
     if python_res.error then
         log("error", "Failed to launch Parakeet Python script: ", to_str_safe(python_res.error))

--- a/parakeet_transcribe.py
+++ b/parakeet_transcribe.py
@@ -200,16 +200,18 @@ def main():
                         help="Pause after sentence-ending punctuation to allow a split")
     parser.add_argument("--comma_pause_ms", type=int, default=120,
                         help="Pause after commas to allow a split")
-    parser.add_argument("--cps", type=float, default=19.0, help="Target characters-per-second reading speed")
+    parser.add_argument("--cps", type=float, default=20.0, help="Target characters-per-second reading speed")
     parser.add_argument("--no_spacy", action="store_true", help="Disable spaCy hints even if available")
     parser.add_argument("--coalesce_gap_ms", type=int, default=360,
                         help="Merge consecutive events if gap ≤ this and 2-line fit/cps ok")
     parser.add_argument("--two_line_threshold", type=float, default=0.60,
                         help="Prefer 2 lines once block length ≥60% of a line")
+    parser.add_argument("--min_two_line_chars", type=int, default=24,
+                        help="Don’t split very short text into 2 lines")
     parser.add_argument(
         "--min_readable_ms",
         type=int,
-        default=1200,
+        default=1100,
         help="Soft minimum on-screen time per cue; short cues extend/merge",
     )
     args = parser.parse_args()
@@ -229,6 +231,7 @@ def main():
     comma_pause_ms = args.comma_pause_ms
     cps = args.cps
     use_spacy = not args.no_spacy
+    min_two_line_chars = args.min_two_line_chars
     min_readable = args.min_readable_ms / 1000.0
     coalesce_gap_ms = args.coalesce_gap_ms
     two_line_threshold = args.two_line_threshold
@@ -433,9 +436,10 @@ def main():
             cps_target=cps,
             snap_fps=fps,
             use_spacy=use_spacy,
-            min_readable=min_readable,
             coalesce_gap_ms=coalesce_gap_ms,
             two_line_threshold=two_line_threshold,
+            min_readable=min_readable,
+            min_two_line_chars=min_two_line_chars,
         )
         _audit(segments, processed)
         write_srt(processed, srt_path)

--- a/parakeet_transcribe.py
+++ b/parakeet_transcribe.py
@@ -381,7 +381,9 @@ def main():
             write_error_srt(err_msg)
             sys.exit(1)
             
-        print(f"\nFull Transcript:\n{full_transcript}\n", file=sys.stderr)
+        # Debug: full transcript is enormous; printing can block when stderr is captured.
+        # if os.environ.get("PARAKEET_VERBOSE") == "1":
+        #     print(f"\nFull Transcript:\n{full_transcript}\n", file=sys.stderr)
 
         # Build segments for post-processing
         segments = []

--- a/parakeet_transcribe.py
+++ b/parakeet_transcribe.py
@@ -211,9 +211,13 @@ def main():
     parser.add_argument(
         "--min_readable_ms",
         type=int,
-        default=1100,
+        default=1200,
         help="Soft minimum on-screen time per cue; short cues extend/merge",
     )
+    parser.add_argument("--max_block_duration_s", type=float, default=7.0,
+                        help="Max duration for a packed 2-line block")
+    parser.add_argument("--max_merge_gap_ms", type=int, default=360,
+                        help="Max gap for orphan merges/borrowing")
     args = parser.parse_args()
 
     audio_path = args.audio_file_path
@@ -235,6 +239,8 @@ def main():
     min_readable = args.min_readable_ms / 1000.0
     coalesce_gap_ms = args.coalesce_gap_ms
     two_line_threshold = args.two_line_threshold
+    max_block_duration_s = args.max_block_duration_s
+    max_merge_gap_ms = args.max_merge_gap_ms
 
     # Define a helper function to write error SRTs immediately
     def write_error_srt(message: str):
@@ -440,6 +446,8 @@ def main():
             two_line_threshold=two_line_threshold,
             min_readable=min_readable,
             min_two_line_chars=min_two_line_chars,
+            max_block_duration_s=max_block_duration_s,
+            max_merge_gap_ms=max_merge_gap_ms,
         )
         _audit(segments, processed)
         write_srt(processed, srt_path)

--- a/parakeet_transcribe.py
+++ b/parakeet_transcribe.py
@@ -200,7 +200,7 @@ def main():
                         help="Pause after sentence-ending punctuation to allow a split")
     parser.add_argument("--comma_pause_ms", type=int, default=120,
                         help="Pause after commas to allow a split")
-    parser.add_argument("--cps", type=float, default=20.0, help="Target characters-per-second reading speed")
+    parser.add_argument("--cps", type=float, default=19.0, help="Target characters-per-second reading speed")
     parser.add_argument("--no_spacy", action="store_true", help="Disable spaCy hints even if available")
     parser.add_argument("--coalesce_gap_ms", type=int, default=360,
                         help="Merge consecutive events if gap ≤ this and 2-line fit/cps ok")
@@ -209,7 +209,7 @@ def main():
     parser.add_argument(
         "--min_readable_ms",
         type=int,
-        default=1100,
+        default=1200,
         help="Soft minimum on-screen time per cue; short cues extend/merge",
     )
     args = parser.parse_args()

--- a/parakeet_transcribe.py
+++ b/parakeet_transcribe.py
@@ -193,9 +193,9 @@ def main():
     parser.add_argument("--max_words", type=int, default=12, help="Maximum words per subtitle when using word segmentation")
     parser.add_argument("--max_duration", type=float, default=6.0, help="Maximum subtitle duration in seconds for word segmentation")
     parser.add_argument("--pause", type=float, default=0.6, help="Inter-word pause (s) that triggers a new subtitle when using word segmentation")
-    parser.add_argument("--fps", type=float, default=24.0, help="Video FPS for frame snapping")
-    parser.add_argument("--max_chars_per_line", type=int, default=40)
-    parser.add_argument("--pause_ms", type=int, default=240, help="Minimum inter-word silence to open a split candidate")
+    parser.add_argument("--fps", type=float, default=24.0, help="Video FPS for frame/frame-edge snapping")
+    parser.add_argument("--max_chars_per_line", type=int, default=42, help="42 CPL per Netflix guidance")
+    parser.add_argument("--pause_ms", type=int, default=240, help="Pause to split phrases (breath-group)")
     parser.add_argument("--punct_pause_ms", type=int, default=160,
                         help="Pause after sentence-ending punctuation to allow a split")
     parser.add_argument("--comma_pause_ms", type=int, default=120,
@@ -204,8 +204,8 @@ def main():
     parser.add_argument("--no_spacy", action="store_true", help="Disable spaCy hints even if available")
     parser.add_argument("--coalesce_gap_ms", type=int, default=360,
                         help="Merge consecutive events if gap ≤ this and 2-line fit/cps ok")
-    parser.add_argument("--two_line_threshold", type=float, default=0.55,
-                        help="Prefer 2 lines once block length ≥ this fraction of a line")
+    parser.add_argument("--two_line_threshold", type=float, default=0.60,
+                        help="Prefer 2 lines once block length ≥60% of a line")
     parser.add_argument(
         "--min_readable_ms",
         type=int,

--- a/parakeet_transcribe.py
+++ b/parakeet_transcribe.py
@@ -381,9 +381,7 @@ def main():
             write_error_srt(err_msg)
             sys.exit(1)
             
-        # Debug: full transcript is enormous; printing can block when stderr is captured.
-        # if os.environ.get("PARAKEET_VERBOSE") == "1":
-        #     print(f"\nFull Transcript:\n{full_transcript}\n", file=sys.stderr)
+        print(f"\nFull Transcript:\n{full_transcript}\n", file=sys.stderr)
 
         # Build segments for post-processing
         segments = []

--- a/segmenter.py
+++ b/segmenter.py
@@ -1,64 +1,40 @@
 from __future__ import annotations
-from typing import List, Dict, Any, Optional, Tuple
-import logging, re, math
+from typing import List, Dict, Any, Tuple, Optional
+import logging, re
 
-PUNCT_END = (".", "!", "?", "…", ":", ";")
-SOFT_PUNCT_END = (",",)  # may end a phrase if there is also a pause
+# ---------- lexicon / heuristics ----------
 CONJ = {"and","but","or","nor","so","yet","for","because","although","though","if","when","while"}
-PREP = {"about","above","across","after","against","along","among","around","at","before","behind",
-        "below","beneath","beside","between","beyond","by","despite","down","during","except","for",
-        "from","in","inside","into","like","near","of","off","on","onto","out","outside","over","past",
-        "since","through","throughout","to","toward","under","underneath","until","up","upon","with",
-        "within","without"}
+PREP = {"about","above","across","after","against","along","among","around","at","before","behind","below","beneath","beside",
+        "between","beyond","by","despite","down","during","except","for","from","in","inside","into","like","near","of","off",
+        "on","onto","out","outside","over","past","since","through","throughout","to","toward","under","underneath","until",
+        "up","upon","with","within","without"}
+HARD_PUNCT = (".","!","?","…",":",";")
+SOFT_PUNCT = (",",)
 
+def _norm(t: str) -> str:
+    return re.sub(r"\s+", " ", (t or "")).strip()
 
-def _normalize(t: str) -> str:
-    return re.sub(r"\s+", " ", t).strip()
-
-
-def _token_text(w: Dict[str, Any]) -> str:
-    # Many ASR word tokens include trailing punctuation, keep it for phrase tests.
+def _wtext(w: Dict[str,Any]) -> str:
     return (w.get("word") or "").strip()
 
-
-def _gap_ms(a_end: float, b_start: float) -> float:
-    return max(0.0, (b_start - a_end) * 1000.0)
-
-
-def _is_titlecase_phrase(words: List[Dict[str,Any]], i: int, j: int) -> bool:
-    # crude “do not break inside” for Names / Proper Noun sequences
-    toks = [_token_text(w) for w in words[i:j]]
-    cap = sum(1 for t in toks if t[:1].isupper())
-    return cap >= max(2, (j - i))
-
-
-def _load_spacy(model: str="en_core_web_sm"):
+def _load_spacy(model="en_core_web_sm"):
     try:
         import spacy
         return spacy.load(model, disable=["lemma","ner"])
     except Exception as e:
-        logging.info("spaCy unavailable (%s) — falling back to rule-only.", e)
+        logging.info("spaCy unavailable: %s", e)
         return None
 
-
-def _spacy_bad_boundary(nlp, text: str, left_text: str, right_text: str) -> bool:
-    """
-    If spaCy is present, discourage breaking between tokens that belong together:
-    - determiners/adjectives + noun
-    - auxiliaries/negations + verb
-    - preposition + its object
-    """
+def _spacy_bad_boundary(nlp, left_text: str, right_text: str) -> bool:
     if not nlp: return False
-    doc = nlp(_normalize(left_text + " | " + right_text))
-    # find the '|' boundary token index
-    bar = [i for i,t in enumerate(doc) if t.text == "|"]
-    if not bar: return False
-    k = bar[0]
-    # left token (k-1) and right token (k+1)
+    doc = nlp(_norm(left_text + " | " + right_text))
+    bars = [i for i,t in enumerate(doc) if t.text == "|"]
+    if not bars: return False
+    k = bars[0]
     L = doc[k-1] if k-1>=0 else None
-    R = doc[k+1] if k+1 < len(doc) else None
+    R = doc[k+1] if k+1<len(doc) else None
     if not L or not R: return False
-    # keep DET/ADJ with NOUN; keep PART/ADV/NEG with VERB/AUX; keep PREP with pobj
+    # keep DET/ADJ with NOUN/PROPN; keep NEG/AUX with VERB; keep ADP with pobj
     bad = (
         (L.pos_ in {"DET","ADJ"} and R.pos_ in {"NOUN","PROPN"}) or
         (L.dep_ in {"neg"} and R.pos_ in {"VERB","AUX"}) or
@@ -67,117 +43,68 @@ def _spacy_bad_boundary(nlp, text: str, left_text: str, right_text: str) -> bool
     )
     return bool(bad)
 
-
-def _words_text(words):
-    return " ".join((w.get("word") or "").strip() for w in words).strip()
-
-
+# ---------- bottom-heavy 2-line shaping (word-preserving) ----------
 def shape_words_into_two_lines_balanced(
-    words,
-    max_chars,
+    words: List[Dict[str,Any]],
+    max_chars: int,
     prefer_two_lines: bool = True,
-    two_line_threshold: float = 0.55,
-):
-    """
-    Input: list of word dicts with 'word','start','end'
-    Returns: (lines_text:list[str], used_words:int, overflow_words:list[dict])
-    - Picks the split that best balances line lengths while respecting soft rules.
-    - Never drops words; overflow becomes continuation.
-    """
-    toks = [(w.get("word") or "").strip() for w in words]
+    two_line_threshold: float = 0.70
+) -> Tuple[List[str], int, List[Dict[str,Any]]]:
+    toks = [_wtext(w) for w in words]
     if not toks:
         return [""], 0, []
-
     total = " ".join(toks)
-    # If it comfortably fits in one line and we don't prefer two lines, keep it.
-    if not prefer_two_lines and len(total) <= max_chars:
-        return [total], len(words), []
-
-    # If we do prefer two lines and it's “long enough”, try to split anyway.
-    want_two = prefer_two_lines and (len(total) >= int(two_line_threshold * max_chars))
-
-    # Candidate breakpoints between words 1..n-1
-    best, best_score = None, -1e9
+    want_two = prefer_two_lines and (len(total) >= int(two_line_threshold*max_chars))
+    # Try all boundaries between words
+    best_cut, best_score = None, -1e9
     for cut in range(1, len(toks)):
         left = " ".join(toks[:cut]); right = " ".join(toks[cut:])
-        # hard limits (no trimming)
         if len(left) > max_chars or len(right) > max_chars:
             continue
-
-        # heuristics
         prev = toks[cut-1].strip(",.;:!?…").lower()
         cur  = toks[cut].strip(",.;:!?…").lower()
-
+        L, R = len(left), len(right)
         score = 0.0
-        # balance: minimize absolute difference
-        score -= abs(len(left) - len(right)) * 1.2
-        # prefer after punctuation / before conj or prep
-        if toks[cut-1][-1:] in (".","!","?","…",",",":",";"): score += 3.0
-        if cur in {"and","but","or","nor","so","yet","for","because","although","though","if","when","while"}: score += 2.0
-        if cur in {"about","above","across","after","against","along","among","around","at","before","behind","below","beneath","beside","between","beyond","by","despite","down","during","except","for","from","in","inside","into","like","near","of","off","on","onto","out","outside","over","past","since","through","throughout","to","toward","under","underneath","until","up","upon","with","within","without"}: score += 1.5
-
-        # avoid splitting tight pairs
+        # balance with bottom-heavy preference
+        score -= abs(L - R) * 0.8
+        if R >= L: score += 1.0
+        else:      score -= 1.0
+        # avoid 1–2 words on top line
+        if len(left.split()) <= 2: score -= 6.0
+        # linguistic: after punctuation / before conj/prep
+        if toks[cut-1][-1:] in HARD_PUNCT + SOFT_PUNCT: score += 3.0
+        if cur in CONJ: score += 2.0
+        if cur in PREP: score += 1.5
+        # avoid breaking after article / subj pronoun
         if prev in {"a","an","the"}: score -= 6.0
         if prev in {"i","you","he","she","we","they","it"}: score -= 2.0
         # avoid very short lines
-        if len(left) < 8 or len(right) < 8: score -= 3.0
-
+        if L < 8 or R < 8: score -= 3.0
         if score > best_score:
-            best_score, best = score, cut
-
-    if best is None:
-        # no legal split
-        if len(total) <= max_chars or not want_two:
+            best_score, best_cut = score, cut
+    if best_cut is None:
+        if not want_two or len(total) <= max_chars:
             return [total], len(words), []
-        # force a safe split at the largest fitting point
+        # force largest fitting cut
         cut = max(i for i in range(1, len(toks)) if len(" ".join(toks[:i])) <= max_chars)
-        best = cut
-
-    left = " ".join(toks[:best]); right = " ".join(toks[best:])
+        best_cut = cut
+    left = " ".join(toks[:best_cut]); right = " ".join(toks[best_cut:])
     if len(right) > max_chars:
-        # overflow flows to continuation (no trimming)
-        # cut right to max_chars without splitting a word; rest is overflow
-        cut_text = right[:max_chars+1]
-        if " " in cut_text:
-            cut_idx = cut_text.rfind(" ")
-            right_vis = right[:cut_idx]
-            overflow  = right[cut_idx+1:].strip().split(" ")
-            used_words = best + len(right_vis.split(" "))
-            return [left, right_vis], used_words, words[used_words:]
-        else:
-            # pathological long token; keep one line
-            return [left, right], best + len(right.split(" ")), []
-    used_words = best + len(right.split(" "))
-    return [left, right], used_words, words[used_words:]
+        # split right side further; overflow becomes continuation words
+        vis = right[:max_chars+1]
+        if " " in vis:
+            k = vis.rfind(" ")
+            right_vis = right[:k]
+            used = best_cut + len(right_vis.split())
+            return [left, right_vis], used, words[used:]
+        return [left, right], best_cut + len(right.split()), []
+    used = best_cut + len(right.split())
+    return [left, right], used, words[used:]
 
-
-def coalesce_short_neighbors(
-    events,
-    gap_ms: int = 180,
-    max_chars_per_line: int = 42,
-    cps_target: float = 20.0,
-):
-    i = 0
-    while i + 1 < len(events):
-        a, b = events[i], events[i + 1]
-        gap = (b["start"] - a["end"]) * 1000.0
-        dur = (b["end"] - a["start"])
-        chars = len(a["text"].replace("\n", " ")) + 1 + len(b["text"].replace("\n", " "))
-        cps = chars / max(0.001, dur)
-        if gap <= gap_ms and cps <= cps_target and chars <= max_chars_per_line * 2:
-            # merge into one event; keep words so timing stays exact
-            a["text"] = a["text"].rstrip() + "\n" + b["text"].lstrip()
-            a["end"] = b["end"]
-            if a.get("words") and b.get("words"):
-                a["words"] = a["words"] + b["words"]
-            del events[i + 1]
-        else:
-            i += 1
-    return events
-
+# ---------- pause+phrase segmentation ----------
 def segment_by_pause_and_phrase(
-    words: List[Dict[str, Any]],
-    max_chars_per_line: int = 40,
+    words: List[Dict[str,Any]],
+    max_chars_per_line: int = 42,
     max_lines: int = 2,
     pause_ms: int = 240,
     punct_pause_ms: int = 160,
@@ -185,148 +112,73 @@ def segment_by_pause_and_phrase(
     cps_target: float = 20.0,
     use_spacy: bool = True,
     spacy_model: str = "en_core_web_sm",
-    two_line_threshold: float = 0.55,
-) -> List[Dict[str, Any]]:
-    """
-    Build segments from ASR word-level tokens using pauses as the primary cue.
-    Punctuation only triggers a split when paired with a sufficient pause.
-    Keeps zero-loss (all words appear). Return list of dicts {start,end,text,words}.
-    """
+    two_line_threshold: float = 0.70,
+) -> List[Dict[str,Any]]:
     nlp = _load_spacy(spacy_model) if use_spacy else None
     out, buf, buf_start = [], [], None
-
     def flush():
         nonlocal buf, buf_start
         if not buf: return
         seg = {
-            "start": float(buf_start if buf_start is not None else buf[0]["start"]),
-            "end": float(buf[-1]["end"]),
-            "text": _normalize(" ".join(_token_text(w) for w in buf)),
+            "start": float(buf[0]["start"]),
+            "end":   float(buf[-1]["end"]),
+            "text":  _norm(" ".join(_wtext(w) for w in buf)),
             "words": buf[:],
         }
-        out.append(seg)
-        buf, buf_start = [], None
-
+        out.append(seg); buf, buf_start = [], None
     for i, w in enumerate(words):
-        t = _token_text(w)
-        if not buf:
-            buf_start = w["start"]
+        t = _wtext(w)
+        if not buf: buf_start = w["start"]
         buf.append(w)
-        # lookahead
-        nxt = words[i+1] if i+1 < len(words) else None
-        gap = _gap_ms(w["end"], nxt["start"]) if nxt else 0.0
-
-        # natural phrase endings
-        ends_hard = t.endswith(PUNCT_END)
-        ends_soft = t.endswith(SOFT_PUNCT_END)
-
-        # conjunction/preposition boundary (prefer BEFORE conj/prep)
+        nxt = words[i+1] if i+1<len(words) else None
+        gap = (nxt["start"] - w["end"])*1000.0 if nxt else 0.0
+        ends_hard = t.endswith(HARD_PUNCT)
+        ends_soft = t.endswith(SOFT_PUNCT)
         conj_or_prep_next = False
         if nxt:
-            ntok = _token_text(nxt).lower().strip("“”\"'()[]")
-            if ntok in CONJ or ntok in PREP:
-                conj_or_prep_next = True
-
-        # Break primarily on PAUSE; punctuation only strengthens the decision.
+            nt = _wtext(nxt).lower().strip("“”\"'()[]")
+            if nt in CONJ or nt in PREP: conj_or_prep_next = True
         should_break = False
-        reason = ""
+        # Primary: break on pause; punctuation only helps if there is a pause
         if gap >= pause_ms:
-            # long enough silence: OK to break anywhere
-            should_break, reason = True, "pause"
+            should_break = True
         elif ends_hard and gap >= punct_pause_ms:
-            # sentence-ending punctuation needs at least a small pause
-            should_break, reason = True, "punct+pause"
+            should_break = True
         elif ends_soft and gap >= comma_pause_ms:
-            # comma needs a pause too, usually shorter
-            should_break, reason = True, "comma+pause"
+            should_break = True
         else:
-            # reading speed pressure: if dense *and* we’re at a soft boundary,
-            # allow a break to keep cps comfy
-            dur = (buf[-1]["end"] - buf[0]["start"])
-            chars = len(_normalize(" ".join(_token_text(x) for x in buf)))
+            # cps pressure at a soft boundary
+            dur = buf[-1]["end"] - buf[0]["start"]
+            chars = len(_norm(" ".join(_wtext(x) for x in buf)))
             cps = chars / max(0.001, dur)
             if cps > cps_target and (ends_soft or conj_or_prep_next):
-                should_break, reason = True, "cps"
-
-        # spaCy veto: avoid bad breaks inside tight word groups
+                should_break = True
+        # spaCy veto for tight groups
         if should_break and nlp and nxt:
-            left_text  = " ".join(_token_text(x) for x in buf)
-            right_text = _token_text(nxt)
-            if _spacy_bad_boundary(nlp, left_text, left_text, right_text):
+            left_text = " ".join(_wtext(x) for x in buf)
+            right_text = _wtext(nxt)
+            if _spacy_bad_boundary(nlp, left_text, right_text):
                 should_break = False
-
-        # Title‑case phrase protection (e.g., "Sana's Village", "Hydra Attack")
-        if should_break and _is_titlecase_phrase(words, max(0, i-1), i+1):
-            should_break = False
-
         if should_break:
             flush()
-
     flush()
-
-    out = coalesce_short_neighbors(
-        out,
-        gap_ms=180,
-        max_chars_per_line=max_chars_per_line,
-        cps_target=cps_target,
-    )
-
-    # two-line shaping (no-loss, word-timing preserving)
-    shaped = []
+    # 2-line shaping preserving word timings, allowing continuations
+    shaped: List[Dict[str,Any]] = []
     for seg in out:
-        cur_words = seg.get("words") or []
-        if not cur_words:
-            shaped.append(seg)
-            continue
-
-        words_list = cur_words
+        words_list = seg.get("words") or []
+        if not words_list:
+            shaped.append(seg); continue
         while words_list:
-            lines_text, used_words, overflow = shape_words_into_two_lines_balanced(
-                words_list,
-                max_chars_per_line,
-                prefer_two_lines=True,
-                two_line_threshold=two_line_threshold,
+            lines, used, overflow = shape_words_into_two_lines_balanced(
+                words_list, max_chars_per_line,
+                prefer_two_lines=True, two_line_threshold=two_line_threshold
             )
-
-            used_block = words_list[:used_words]
-            new_seg = {
+            used_block = words_list[:used]
+            shaped.append({
                 "start": float(used_block[0]["start"]),
-                "end": float(used_block[-1]["end"]),
-                "text": "\n".join(lines_text[:2]),
+                "end":   float(used_block[-1]["end"]),
+                "text":  "\n".join(lines[:2]),
                 "words": used_block,
-            }
-            shaped.append(new_seg)
-
-            # Next iteration processes the true overflow words
+            })
             words_list = overflow
     return shaped
-
-
-def shape_lines_no_loss(text: str, max_chars: int, max_lines: int) -> Tuple[list[str], str]:
-    text = _normalize(text)
-    if max_lines <= 1 or len(text) <= max_chars:
-        return [text], ""
-    words = text.split(" ")
-    # greedy fill for line1
-    line1, line2 = [], []
-    for w in words:
-        trial = " ".join(line1 + [w])
-        if len(trial) <= max_chars:
-            line1.append(w); continue
-        break
-    rem = words[len(line1):]
-    # prefer breaks after punctuation / before conj/prep
-    if rem and line1:
-        if not (line1[-1][-1:] in PUNCT_END or line1[-1][-1:] in SOFT_PUNCT_END):
-            # try to move last word(s) to line2 if nicer
-            while line1 and (len(" ".join(line1)) > max_chars or
-                             (rem and (rem[0].lower() in CONJ or rem[0].lower() in PREP))):
-                rem.insert(0, line1.pop())
-    l1 = " ".join(line1).strip()
-    l2 = " ".join(rem).strip()
-    if len(l2) > max_chars:
-        # overflow becomes continuation; do not trim visible text
-        cut = l2[:max_chars+1].rsplit(" ", 1)[0] if " " in l2[:max_chars+1] else l2[:max_chars]
-        overflow = l2[len(cut):].strip()
-        return [l1, cut], overflow
-    return [l1, l2], ""

--- a/segmenter.py
+++ b/segmenter.py
@@ -45,12 +45,12 @@ def _spacy_bad_boundary(nlp, left_text: str, right_text: str) -> bool:
 
 # ---------- bottom-heavy 2-line shaping (word-preserving) ----------
 def shape_words_into_two_lines_balanced(
-    words: List[Dict[str,Any]],
+    words: List[Dict[str, Any]],
     max_chars: int,
     prefer_two_lines: bool = True,
     two_line_threshold: float = 0.70,
     min_two_line_chars: int = 24,
-) -> Tuple[List[str], int, List[Dict[str,Any]]]:
+) -> Tuple[List[str], int, List[Dict[str, Any]]]:
     toks = [_wtext(w) for w in words]
     if not toks:
         return [""], 0, []
@@ -113,7 +113,7 @@ def segment_by_pause_and_phrase(
     pause_ms: int = 240,
     punct_pause_ms: int = 160,
     comma_pause_ms: int = 120,
-    cps_target: float = 19.0,
+    cps_target: float = 20.0,
     use_spacy: bool = True,
     spacy_model: str = "en_core_web_sm",
     two_line_threshold: float = 0.70,
@@ -168,24 +168,28 @@ def segment_by_pause_and_phrase(
             flush()
     flush()
     # 2-line shaping preserving word timings, allowing continuations
-    shaped: List[Dict[str,Any]] = []
+    shaped: List[Dict[str, Any]] = []
     for seg in out:
         words_list = seg.get("words") or []
         if not words_list:
-            shaped.append(seg); continue
-            while words_list:
-                lines, used, overflow = shape_words_into_two_lines_balanced(
-                    words_list, max_chars_per_line,
-                    prefer_two_lines=True,
-                    two_line_threshold=two_line_threshold,
-                    min_two_line_chars=min_two_line_chars,
-                )
+            shaped.append(seg)
+            continue
+        while words_list:
+            lines, used, overflow = shape_words_into_two_lines_balanced(
+                words_list,
+                max_chars=max_chars_per_line,
+                prefer_two_lines=True,
+                two_line_threshold=two_line_threshold,
+                min_two_line_chars=min_two_line_chars,
+            )
             used_block = words_list[:used]
-            shaped.append({
-                "start": float(used_block[0]["start"]),
-                "end":   float(used_block[-1]["end"]),
-                "text":  "\n".join(lines[:2]),
-                "words": used_block,
-            })
+            shaped.append(
+                {
+                    "start": float(used_block[0]["start"]),
+                    "end": float(used_block[-1]["end"]),
+                    "text": "\n".join(lines[:2]),
+                    "words": used_block,
+                }
+            )
             words_list = overflow
     return shaped

--- a/srt_utils.py
+++ b/srt_utils.py
@@ -499,8 +499,8 @@ def normalize_timing_netflix(
         orig_end = cur["end"]
         orig_start_nxt = nxt["start"]
         take = min(spare_gap, borrow)
+        # use silent gap without shifting the next cue's start
         cur["end"] += take
-        nxt["start"] += take
         borrow -= take
         if borrow > 0:
             cur["end"] += borrow
@@ -528,8 +528,8 @@ def normalize_timing_netflix(
         orig_start = cur["start"]
         orig_end_prev = prev["end"]
         take = min(spare_gap, borrow)
+        # pull from available gap without moving the previous cue's end
         cur["start"] -= take
-        prev["end"] -= take
         borrow -= take
         if borrow > 0:
             cur["start"] -= borrow

--- a/srt_utils.py
+++ b/srt_utils.py
@@ -1,127 +1,13 @@
 from __future__ import annotations
-import math
-import re
 from typing import List, Dict, Any, Tuple
+import math, re
 from segmenter import segment_by_pause_and_phrase, shape_words_into_two_lines_balanced
 
-# Helpers for enforcing minimum readable duration
-PUNCT = (".", "!", "?", "…", ",", ":", ";", "-", "—")
+SPACES = re.compile(r"\s+")
+def normalize_text(t: str) -> str:
+    return SPACES.sub(" ", (t or "")).strip()
 
-__all__ = [
-    "enforce_min_readable",
-    "postprocess_segments",
-    "frame_quantize",
-    "write_srt",
-    "format_time_srt",
-    "srt_ts",
-    "normalize_text",
-    "pack_into_two_line_blocks",
-]
-
-
-def pack_into_two_line_blocks(
-    events: List[Dict[str, Any]],
-    max_chars_per_line: int = 40,
-    cps_target: float = 20.0,
-    coalesce_gap_ms: int = 360,
-    two_line_threshold: float = 0.55,
-) -> List[Dict[str, Any]]:
-    """Greedily merge consecutive events into a single 2-line block when:
-      - the inter-event gap ≤ coalesce_gap_ms
-      - shaped text fits in 2 lines (no overflow)
-      - chars-per-second stays within cps_target
-    Preserves word timings; zero text loss."""
-    out: List[Dict[str, Any]] = []
-    i = 0
-    while i < len(events):
-        blk_words = events[i].get("words") or []
-        if not blk_words:
-            out.append(events[i])
-            i += 1
-            continue
-        start = float(blk_words[0]["start"])
-        end = float(events[i]["end"])
-        j = i
-
-        while j + 1 < len(events):
-            gap_ms = int(round((events[j + 1]["start"] - events[j]["end"]) * 1000))
-            if gap_ms > coalesce_gap_ms:
-                break
-
-            nxt_words = events[j + 1].get("words") or []
-            cand_words = blk_words + nxt_words
-            lines, _, overflow = shape_words_into_two_lines_balanced(
-                cand_words,
-                max_chars_per_line,
-                prefer_two_lines=True,
-                two_line_threshold=two_line_threshold,
-            )
-            if overflow:
-                break
-
-            cand_text = " ".join(w.get("word", "").strip() for w in cand_words)
-            cand_end = float(events[j + 1]["end"])
-            cps = len(cand_text.replace("\n", " ").strip()) / max(0.001, (cand_end - start))
-            if cps > cps_target:
-                break
-
-            blk_words = cand_words
-            end = cand_end
-            j += 1
-
-        lines, _, overflow = shape_words_into_two_lines_balanced(
-            blk_words,
-            max_chars_per_line,
-            prefer_two_lines=True,
-            two_line_threshold=two_line_threshold,
-        )
-        block = {
-            "start": float(blk_words[0]["start"]),
-            "end": float(end),
-            "text": "\n".join(lines[:2]),
-            "words": blk_words,
-        }
-        out.append(block)
-
-        # Practically unreachable because we avoid overflow before packing,
-        # but keep it correct just in case.
-        while overflow:
-            ow = overflow
-            lines2, used2, overflow = shape_words_into_two_lines_balanced(
-                ow,
-                max_chars_per_line,
-                prefer_two_lines=True,
-                two_line_threshold=two_line_threshold,
-            )
-            used_block2 = ow[:used2]
-            out.append(
-                {
-                    "start": float(used_block2[0]["start"]),
-                    "end": float(used_block2[-1]["end"]),
-                    "text": "\n".join(lines2[:2]),
-                    "words": used_block2,
-                }
-            )
-
-        i = j + 1
-    return out
-
-
-def _audit_monotonic_and_lossless(evts):
-    # monotonic
-    for i in range(1, len(evts)):
-        if evts[i]["start"] < evts[i - 1]["end"]:
-            print(
-                f"[WARN] overlap {i}: {evts[i-1]['end']:.3f} -> {evts[i]['start']:.3f}"
-            )
-    # lossless text (approximate)
-    def flat_text(events):
-        return " ".join(e["text"].replace("\n", " ").strip() for e in events)
-
-    return flat_text(evts)
-
-
-def format_time_srt(t: float) -> str:
+def srt_ts(t: float) -> str:
     if not math.isfinite(t) or t < 0:
         t = 0.0
     total_ms = int(round(t * 1000))
@@ -133,86 +19,231 @@ def format_time_srt(t: float) -> str:
     h = total_m // 60
     return f"{h:02}:{m:02}:{s:02},{ms:03}"
 
+def format_time_srt(t: float) -> str:
+    return srt_ts(t)
 
-def srt_ts(t: float) -> str:
-    return format_time_srt(t)
+def write_srt(events: List[Dict[str,Any]], out_path: str) -> None:
+    with open(out_path, "w", encoding="utf-8") as f:
+        for i, ev in enumerate(events, 1):
+            f.write(f"{i}\n{srt_ts(ev['start'])} --> {srt_ts(ev['end'])}\n{ev['text'].strip()}\n\n")
 
+# ---------- 2-line packer: merge across short breaths if it fits & cps ok ----------
+def pack_into_two_line_blocks(
+    events: List[Dict[str, Any]],
+    max_chars_per_line: int = 42,
+    cps_target: float = 20.0,
+    coalesce_gap_ms: int = 360,
+    two_line_threshold: float = 0.60,
+) -> List[Dict[str, Any]]:
+    out: List[Dict[str,Any]] = []
+    i = 0
+    while i < len(events):
+        blk = events[i]
+        bw = blk.get("words") or []
+        if not bw:
+            out.append(blk); i += 1; continue
+        start = float(bw[0]["start"])
+        end = float(blk["end"])
+        j = i
+        while j+1 < len(events):
+            gap_ms = int(round((events[j+1]["start"] - events[j]["end"]) * 1000))
+            if gap_ms > coalesce_gap_ms: break
+            cw = (events[j+1].get("words") or [])
+            cand = bw + cw
+            lines, used, overflow = shape_words_into_two_lines_balanced(
+                cand, max_chars_per_line,
+                prefer_two_lines=True, two_line_threshold=two_line_threshold
+            )
+            if overflow: break
+            txt = " ".join((w.get("word","") or "").strip() for w in cand)
+            cps = len(txt) / max(0.001, (events[j+1]["end"] - start))
+            if cps > cps_target: break
+            bw = cand; end = float(events[j+1]["end"]); j += 1
+        lines, used, overflow = shape_words_into_two_lines_balanced(
+            bw, max_chars_per_line, prefer_two_lines=True, two_line_threshold=two_line_threshold
+        )
+        used_block = bw[:used]
+        out.append({
+            "start": float(used_block[0]["start"]),
+            "end":   float(used_block[-1]["end"]),
+            "text":  "\n".join(lines[:2]),
+            "words": used_block,
+        })
+        i = j + 1
+    return out
 
-def _smart_join(a: str, b: str) -> str:
-    """Join two subtitle texts with minimal punctuation artifacts."""
-    if not a:
-        return b
-    if not b:
-        return a
-    if a.endswith(("-", "—")):
-        return (a + b).strip()
-    if a.endswith(PUNCT):
-        return (a + " " + b).replace("  ", " ").strip()
-    return (a + " " + b).replace("  ", " ").strip()
-
-
-def enforce_min_readable(
-    events: list[dict],
+# ---------- orphan-aware min-readable (merges tiny one/two-word singles) ----------
+def enforce_min_readable_v2(
+    events: List[Dict[str,Any]],
     min_dur: float = 1.10,
-    max_dur: float = 7.0,
-    reflow: bool = True,
-    max_chars_per_line: int = 40,
+    cps_target: float = 20.0,
+    max_chars_per_line: int = 42,
+    orphan_words: int = 2,
+    orphan_chars: int = 12,
 ):
-    """Extend or merge very short cues so they remain readable."""
     i = 0
     while i < len(events):
         e = events[i]
         dur = e["end"] - e["start"]
-        if dur >= min_dur:
-            i += 1
-            continue
-
-        # 1) try to extend into the gap before the next cue
-        if i + 1 < len(events):
-            gap = max(0.0, events[i + 1]["start"] - e["end"])
-            take = min(min_dur - dur, gap)
-            if take > 0:
-                e["end"] += take
-                dur = e["end"] - e["start"]
-
-        # 2) if still short, merge with closer neighbor
-        if dur < min_dur:
-            prev_gap = (e["start"] - events[i - 1]["end"]) if i > 0 else 1e9
-            next_gap = (events[i + 1]["start"] - e["end"]) if i + 1 < len(events) else 1e9
-            if next_gap <= prev_gap and i + 1 < len(events):
-                nxt = events[i + 1]
-                e["text"] = _smart_join(e["text"], nxt["text"])
-                e["end"] = nxt["end"]
-                del events[i + 1]
-            elif i > 0:
-                prv = events[i - 1]
-                prv["text"] = _smart_join(prv["text"], e["text"])
-                prv["end"] = e["end"]
-                del events[i]
-                i -= 1
-                continue
+        text_flat = e["text"].replace("\n"," ").strip()
+        n_words = len(e.get("words") or [])
+        is_orphan = (n_words <= orphan_words) or (len(text_flat) <= orphan_chars)
+        if dur >= min_dur and not is_orphan:
+            i += 1; continue
+        # try extend into next gap
+        if i+1 < len(events):
+            room = max(0.0, events[i+1]["start"] - e["end"])
+            need = min_dur - dur
+            take = min(need, room)
+            if take > 0: e["end"] += take; dur = e["end"] - e["start"]
+        if dur >= min_dur and not is_orphan:
+            i += 1; continue
+        # try merge with prev/next (score by 2-line fit & cps)
+        def score_merge(left, right):
+            lw, rw = (left.get("words") or []), (right.get("words") or [])
+            if not lw or not rw: return -1e9, None
+            cand = lw + rw
+            lines, used, overflow = shape_words_into_two_lines_balanced(
+                cand, max_chars_per_line, prefer_two_lines=True, two_line_threshold=0.55
+            )
+            if overflow: return -1e9, None
+            txt = " ".join((w.get("word","") or "").strip() for w in cand)
+            cps = len(txt) / max(0.001, (right["end"] - left["start"]))
+            if cps > cps_target: return -1e9, None
+            diff = abs(len(lines[0]) - len(lines[-1]))
+            return -(diff + cps*0.4), (cand, "\n".join(lines[:2]))
+        best = None
+        if i>0:
+            s,p = score_merge(events[i-1], e)
+            if p: best=("prev", s, p)
+        if i+1 < len(events):
+            s,p = score_merge(e, events[i+1])
+            if p and (best is None or s>best[1]):
+                best=("next", s, p)
+        if best:
+            which, _, (cand, text) = best
+            if which=="prev":
+                prev = events[i-1]
+                prev["text"] = text
+                prev["end"]  = events[i]["end"]
+                if prev.get("words") and e.get("words"):
+                    prev["words"] = prev["words"] + e["words"]
+                del events[i]; i -= 1; continue
+            else:
+                nxt = events[i+1]
+                e["text"] = text
+                e["end"]  = nxt["end"]
+                if e.get("words") and nxt.get("words"):
+                    e["words"] = e["words"] + nxt["words"]
+                del events[i+1]; continue
+        # last resort: merge orphan forward/back
+        if is_orphan:
+            if i+1 < len(events):
+                nxt = events[i+1]
+                e["text"] = e["text"].rstrip()+" "+nxt["text"].lstrip()
+                e["end"]  = nxt["end"]
+                if e.get("words") and nxt.get("words"):
+                    e["words"] = e["words"] + nxt["words"]
+                del events[i+1]; continue
+            elif i>0:
+                prev = events[i-1]
+                prev["text"] = prev["text"].rstrip()+" "+e["text"].lstrip()
+                prev["end"]  = e["end"]
+                if prev.get("words") and e.get("words"):
+                    prev["words"] = prev["words"] + e["words"]
+                del events[i]; i -= 1; continue
         i += 1
-
-    if reflow:
-        from segmenter import shape_lines_no_loss
-
-        new = []
-        for ev in events:
-            lines, overflow = shape_lines_no_loss(ev["text"], max_chars_per_line, 2)
-            ev["text"] = "\n".join(lines)
-            new.append(ev)
-            while overflow:
-                cont = {"start": ev["end"], "end": ev["end"], "text": overflow}
-                lines, overflow = shape_lines_no_loss(cont["text"], max_chars_per_line, 2)
-                cont["text"] = "\n".join(lines)
-                new.append(cont)
-        return new
     return events
 
+# ---------- Netflix timing normalizer ----------
+def _spf(fps: float) -> float: return 1.0/max(1e-6, fps)
+def _floor(t: float, fps: float) -> float:
+    s=_spf(fps); return math.floor(t/s)*s
+def _ceil(t: float, fps: float) -> float:
+    s=_spf(fps); return math.ceil(t/s)*s
 
+def normalize_timing_netflix(
+    events: List[Dict[str,Any]],
+    fps: float,
+    linger_after_audio_ms: int = 500,
+    min_gap_frames: int = 2,
+    close_range_frames: Tuple[int,int] = (3,11),  # 24/23.976 only
+    small_gap_floor_s: float = 0.5,
+) -> List[Dict[str,Any]]:
+    if not events: return events
+    spf=_spf(fps)
+    is_24ish = abs(fps-24.0)<0.2 or abs(fps-23.976)<0.2
+    # 1) Start on first audio frame; End on last audio frame (we'll linger later if safe)
+    for ev in events:
+        ws = ev.get("words") or []
+        if ws:
+            ev["start"] = _floor(ws[0]["start"], fps)      # never late
+            ev["end"]   = _ceil (ws[-1]["end"], fps)
+        if ev["end"] <= ev["start"]:
+            ev["end"] = ev["start"] + spf
+    # 2) Reserve 20 frames for 1–2-word cues; extend longer slightly when space allows
+    for i,ev in enumerate(events):
+        ws = ev.get("words") or []
+        need = 20*spf if len(ws)<=2 else 0.0
+        if need and (ev["end"]-ev["start"]) < need:
+            if i+1<len(events):
+                room = max(0.0, events[i+1]["start"] - ev["end"])
+                take = min(need - (ev["end"]-ev["start"]), room)
+                if take>0: ev["end"] += take
+    # 3) Linger +0.5s ONLY when safe (i.e., there is NOT an immediate next subtitle)
+    #    Safe = next.start - last_audio_end >= 0.5s. Otherwise don't linger here.
+    for i,ev in enumerate(events):
+        ws = ev.get("words") or []
+        if not ws: continue
+        last_audio_end = ws[-1]["end"]
+        if i+1 < len(events):
+            gap_to_next = events[i+1]["start"] - last_audio_end
+            if gap_to_next >= small_gap_floor_s:
+                target = min(last_audio_end + linger_after_audio_ms/1000.0,
+                             events[i+1]["start"] - min_gap_frames*spf)
+                if target > ev["end"]:
+                    ev["end"] = target
+        else:
+            # last cue in file
+            target = last_audio_end + linger_after_audio_ms/1000.0
+            if target > ev["end"]:
+                ev["end"] = target
+    # 4) Chaining / closing gaps
+    i=0
+    while i < len(events)-1:
+        a, b = events[i], events[i+1]
+        a["end"] = _ceil(a["end"], fps)
+        b["start"] = _floor(b["start"], fps)
+        gap_s = b["start"] - a["end"]
+        gap_f = int(round(gap_s / spf))
+        if gap_f < min_gap_frames:
+            # pull 'a' back so gap is ≥2 frames
+            a["end"] = b["start"] - min_gap_frames*spf
+        elif is_24ish and (3 <= gap_f <= 11):
+            # close 3–11f to 2f
+            a["end"] = b["start"] - min_gap_frames*spf
+        else:
+            # general rule: either 2f or ≥0.5s
+            if gap_s < small_gap_floor_s:
+                a["end"] = b["start"] - min_gap_frames*spf
+        # never invert
+        if a["end"] <= a["start"]:
+            a["end"] = a["start"] + spf
+        i += 1
+    # 5) final snap & monotonic
+    for i,ev in enumerate(events):
+        ev["start"] = _floor(ev["start"], fps)
+        ev["end"]   = _ceil (ev["end"], fps)
+        if i>0 and ev["start"] < events[i-1]["end"] + min_gap_frames*spf:
+            ev["start"] = events[i-1]["end"] + min_gap_frames*spf
+        if ev["end"] <= ev["start"]:
+            ev["end"] = ev["start"] + spf
+    return events
+
+# ---------- top-level postprocess ----------
 def postprocess_segments(
-    segments: List[Dict[str, Any]],
-    max_chars_per_line: int = 40,
+    segments: List[Dict[str,Any]],
+    max_chars_per_line: int = 42,
     max_lines: int = 2,
     pause_ms: int = 240,
     punct_pause_ms: int = 160,
@@ -220,23 +251,17 @@ def postprocess_segments(
     cps_target: float = 20.0,
     snap_fps: float | None = None,
     use_spacy: bool = True,
-    min_readable: float = 1.1,
     coalesce_gap_ms: int = 360,
-    two_line_threshold: float = 0.55,
-) -> List[Dict[str, Any]]:
-    """Segment words by pauses and phrases, shape lines, and quantize to frames."""
-    # flatten word list (Parakeet provides accurate word timestamps)
-    words: List[Dict[str, Any]] = []
+    two_line_threshold: float = 0.60,
+    min_readable: float = 1.10,
+) -> List[Dict[str,Any]]:
+    # Flatten word list from raw ASR segments
+    words: List[Dict[str,Any]] = []
     for seg in segments:
-        ws = seg.get("words") or []
-        for w in ws:
+        for w in (seg.get("words") or []):
             if "start" in w and "end" in w and w.get("word"):
-                words.append({
-                    "word": w["word"],
-                    "start": float(w["start"]),
-                    "end": float(w["end"]),
-                })
-
+                words.append({"word": w["word"], "start": float(w["start"]), "end": float(w["end"])})
+    # Segment on pauses/phrases, shape to 2 lines (word-preserving)
     events = segment_by_pause_and_phrase(
         words,
         max_chars_per_line=max_chars_per_line,
@@ -248,7 +273,7 @@ def postprocess_segments(
         use_spacy=use_spacy,
         two_line_threshold=two_line_threshold,
     )
-
+    # Merge small neighbors into calm 2-line blocks
     events = pack_into_two_line_blocks(
         events,
         max_chars_per_line=max_chars_per_line,
@@ -256,54 +281,21 @@ def postprocess_segments(
         coalesce_gap_ms=coalesce_gap_ms,
         two_line_threshold=two_line_threshold,
     )
-
-    events = enforce_min_readable(
+    # Eliminate quick singles (orphans) and short flashes
+    events = enforce_min_readable_v2(
         events,
         min_dur=min_readable,
-        max_dur=7.0,
-        reflow=True,
+        cps_target=cps_target,
         max_chars_per_line=max_chars_per_line,
     )
-
-    _ = _audit_monotonic_and_lossless(events)
-
-    # frame-quantize: floor starts, ceil ends (prevents late starts)
-    events = frame_quantize(events, snap_fps)
+    # Netflix timing: linger-only-when-safe + chaining + 20f for 1–2 words
+    if snap_fps:
+        events = normalize_timing_netflix(
+            events,
+            fps=snap_fps,
+            linger_after_audio_ms=500,
+            min_gap_frames=2,
+            close_range_frames=(3,11),
+            small_gap_floor_s=0.5,
+        )
     return events
-
-
-def frame_quantize(items: List[Dict[str, Any]], fps: float | None) -> List[Dict[str, Any]]:
-    if not fps:
-        return items
-    q = 1.0 / fps
-    for it in items:
-        it["start"] = math.floor(it["start"] / q) * q
-        it["end"] = math.ceil(it["end"] / q) * q
-        if it["end"] <= it["start"]:
-            it["end"] = it["start"] + (1.0 / 100.0)  # 10 ms guard
-    # de-overlap without delaying starts; pull previous end back if needed
-    for i in range(1, len(items)):
-        prev, cur = items[i - 1], items[i]
-        if cur["start"] < prev["end"]:
-            prev["end"] = min(prev["end"], cur["start"])
-    return items
-
-
-def write_srt(events: List[Dict[str, Any]], out_path: str) -> None:
-    with open(out_path, "w", encoding="utf-8") as f:
-        for i, ev in enumerate(events, 1):
-            start = format_time_srt(ev["start"])
-            end = format_time_srt(ev["end"])
-            text = ev["text"].strip()
-            f.write(f"{i}\n{start} --> {end}\n{text}\n\n")
-
-
-SPACES = re.compile(r"\s+")
-MULTI_DOTS = re.compile(r"\.{3,}")
-
-
-def normalize_text(t: str) -> str:
-    t = t.replace("\u2014", "—").replace("\u2013", "–")
-    t = MULTI_DOTS.sub("…", t)
-    t = SPACES.sub(" ", t).strip()
-    return t

--- a/srt_utils.py
+++ b/srt_utils.py
@@ -501,7 +501,7 @@ def normalize_timing_netflix(
         take = min(spare_gap, borrow)
         # use silent gap without shifting the next cue's start
         cur["end"] += take
-        borrow -= take
+        borrow = max(0.0, borrow - take)
         if borrow > 0:
             cur["end"] += borrow
             nxt["start"] += borrow
@@ -530,7 +530,7 @@ def normalize_timing_netflix(
         take = min(spare_gap, borrow)
         # pull from available gap without moving the previous cue's end
         cur["start"] -= take
-        borrow -= take
+        borrow = max(0.0, borrow - take)
         if borrow > 0:
             cur["start"] -= borrow
             prev["end"] -= borrow

--- a/srt_utils.py
+++ b/srt_utils.py
@@ -458,225 +458,57 @@ def normalize_timing_netflix(
         if a["end"] <= a["start"]:
             a["end"] = a["start"] + spf
         i += 1
-    # 5) final snap & monotonic (safe clamp, never late beyond audio +2f)
-    for i, ev in enumerate(events):
+    # 5) final snap & monotonic (do NOT make starts late)
+    for i,ev in enumerate(events):
         ev["start"] = _floor(ev["start"], fps)
-        ev["end"] = _ceil(ev["end"], fps)
-        if i > 0:
+        ev["end"]   = _ceil (ev["end"], fps)
+        if i>0:
             ws = ev.get("words") or []
             audio_start_floor = _floor(ws[0]["start"], fps) if ws else ev["start"]
-            lower = events[i-1]["end"] + min_gap_frames*spf
-            upper = audio_start_floor + min_gap_frames*spf
-            if upper < lower:
-                upper = lower
+            lower = events[i-1]["end"] + min_gap_frames*spf + 1e-6
+            upper = max(lower, audio_start_floor + min_gap_frames*spf)
             ev["start"] = min(max(ev["start"], lower), upper)
         if ev["end"] <= ev["start"]:
             ev["end"] = ev["start"] + spf
 
-    # 6) post-quantization gap normalizer
+    # 6) post-quantization consolidation
+    # Chain gaps <0.5s to 2-frame separations
     for i in range(len(events) - 1):
         gap = events[i+1]["start"] - events[i]["end"]
-        gap_f = int(round(gap / spf))
-        if gap_f <= 0:
-            events[i]["end"] = events[i+1]["start"] - min_gap_frames*spf
-        elif is_24ish and 3 <= gap_f <= 11:
-            events[i]["end"] = events[i+1]["start"] - min_gap_frames*spf
-        if events[i]["end"] <= events[i]["start"]:
-            events[i]["end"] = events[i]["start"] + spf
-
-    # helpers for duration and CPS borrowing
-    def _borrow_from_right(idx: int, need: float, tolerance: float = 0.002) -> bool:
-        if idx + 1 >= len(events):
-            return False
-        cur, nxt = events[idx], events[idx + 1]
-        gap = nxt["start"] - cur["end"]
-        spare_gap = max(0.0, gap - min_gap_frames*spf)
-        spare_nxt = max(0.0, (nxt["end"] - nxt["start"]) - min_dur)
-        avail = spare_gap + spare_nxt
-        if avail <= 0:
-            return False
-        borrow = min(need, avail)
-        orig_end = cur["end"]
-        orig_start_nxt = nxt["start"]
-        take = min(spare_gap, borrow)
-        # use silent gap without shifting the next cue's start
-        cur["end"] += take
-        borrow = max(0.0, borrow - take)
-        if borrow > 0:
-            cur["end"] += borrow
-            nxt["start"] += borrow
-        dur_nxt = nxt["end"] - nxt["start"]
-        txt_nxt = " ".join((w.get("word", "") or "").strip() for w in nxt.get("words") or [])
-        cps_nxt = len(txt_nxt) / max(0.001, dur_nxt)
-        if dur_nxt + tolerance < min_dur or cps_nxt > cps_target:
-            cur["end"] = orig_end
-            nxt["start"] = orig_start_nxt
-            return False
-        return True
-
-    def _borrow_from_left(idx: int, need: float, tolerance: float = 0.002) -> bool:
-        if idx == 0:
-            return False
-        prev, cur = events[idx - 1], events[idx]
-        gap = cur["start"] - prev["end"]
-        spare_gap = max(0.0, gap - min_gap_frames*spf)
-        spare_prev = max(0.0, (prev["end"] - prev["start"]) - min_dur)
-        avail = spare_gap + spare_prev
-        if avail <= 0:
-            return False
-        borrow = min(need, avail)
-        orig_start = cur["start"]
-        orig_end_prev = prev["end"]
-        take = min(spare_gap, borrow)
-        # pull from available gap without moving the previous cue's end
-        cur["start"] -= take
-        borrow = max(0.0, borrow - take)
-        if borrow > 0:
-            cur["start"] -= borrow
-            prev["end"] -= borrow
-        dur_prev = prev["end"] - prev["start"]
-        txt_prev = " ".join((w.get("word", "") or "").strip() for w in prev.get("words") or [])
-        cps_prev = len(txt_prev) / max(0.001, dur_prev)
-        if dur_prev + tolerance < min_dur or cps_prev > cps_target:
-            cur["start"] = orig_start
-            prev["end"] = orig_end_prev
-            return False
-        return True
-
-    # 7) duration repair (ensure ≥20f)
-    tolerance = 0.002
-    min_dur = 20 * spf
+        if gap < small_gap_floor_s:
+            desired = events[i+1]["start"] - min_gap_frames*spf
+            if desired > events[i]["end"]:
+                events[i]["end"] = desired
+    # Merge adjacent cues with tiny gaps when safe
     i = 0
-    while i < len(events):
-        ev = events[i]
-        dur = ev["end"] - ev["start"]
-        if dur + tolerance < min_dur:
-            need = min_dur - dur
-            if _borrow_from_right(i, need):
-                continue
-            if _borrow_from_left(i, need):
-                continue
-            merged = False
-            if i + 1 < len(events):
+    while i < len(events) - 1:
+        gap = events[i+1]["start"] - events[i]["end"]
+        if gap <= min_gap_frames*spf:
+            b_text = (events[i+1].get("text") or "").lstrip()
+            if not (b_text.startswith("-") or b_text.startswith("[")):
                 ok, payload = _can_merge_pair(
-                    ev,
-                    events[i + 1],
-                    max_chars_per_line,
-                    cps_target,
-                    two_line_threshold,
-                    min_two_line_chars,
-                    max_block_duration_s,
-                    shaper,
+                    events[i], events[i+1],
+                    max_chars_per_line, cps_target,
+                    two_line_threshold, min_two_line_chars,
+                    max_block_duration_s, shaper,
                 )
-                if ok and payload:
+                dur = events[i+1]["end"] - events[i]["start"]
+                if ok and payload and dur >= 20*spf:
                     words, text = payload
-                    ev["text"] = text
-                    ev["end"] = events[i + 1]["end"]
-                    if ev.get("words") and events[i + 1].get("words"):
-                        ev["words"] = ev["words"] + events[i + 1]["words"]
-                    del events[i + 1]
-                    merged = True
-            if not merged and i > 0:
-                ok, payload = _can_merge_pair(
-                    events[i - 1],
-                    ev,
-                    max_chars_per_line,
-                    cps_target,
-                    two_line_threshold,
-                    min_two_line_chars,
-                    max_block_duration_s,
-                    shaper,
-                )
-                if ok and payload:
-                    prev = events[i - 1]
-                    words, text = payload
-                    prev["text"] = text
-                    prev["end"] = ev["end"]
-                    if prev.get("words") and ev.get("words"):
-                        prev["words"] = prev["words"] + ev["words"]
-                    del events[i]
-                    i -= 1
+                    events[i]["text"] = text
+                    events[i]["end"] = events[i+1]["end"]
+                    if events[i].get("words") and events[i+1].get("words"):
+                        events[i]["words"] = events[i]["words"] + events[i+1]["words"]
+                    del events[i+1]
                     continue
         i += 1
-
-    # 8) reading speed balance (borrow before merge)
-    i = 0
-    while i < len(events):
-        ev = events[i]
-        txt = " ".join((w.get("word", "") or "").strip() for w in ev.get("words") or [])
-        dur = ev["end"] - ev["start"]
-        cps = len(txt) / max(0.001, dur)
-        if cps > cps_target:
-            need = (len(txt) / cps_target) - dur
-            if _borrow_from_right(i, need):
-                continue
-            if _borrow_from_left(i, need):
-                continue
-            merged = False
-            if i + 1 < len(events):
-                ok, payload = _can_merge_pair(
-                    ev,
-                    events[i + 1],
-                    max_chars_per_line,
-                    cps_target,
-                    two_line_threshold,
-                    min_two_line_chars,
-                    max_block_duration_s,
-                    shaper,
-                )
-                if ok and payload:
-                    words, text = payload
-                    ev["text"] = text
-                    ev["end"] = events[i + 1]["end"]
-                    if ev.get("words") and events[i + 1].get("words"):
-                        ev["words"] = ev["words"] + events[i + 1]["words"]
-                    del events[i + 1]
-                    continue
-            if i > 0:
-                ok, payload = _can_merge_pair(
-                    events[i - 1],
-                    ev,
-                    max_chars_per_line,
-                    cps_target,
-                    two_line_threshold,
-                    min_two_line_chars,
-                    max_block_duration_s,
-                    shaper,
-                )
-                if ok and payload:
-                    prev = events[i - 1]
-                    words, text = payload
-                    prev["text"] = text
-                    prev["end"] = ev["end"]
-                    if prev.get("words") and ev.get("words"):
-                        prev["words"] = prev["words"] + ev["words"]
-                    del events[i]
-                    i -= 1
-                    continue
-        i += 1
-
-    # 9) final snap & validate
-    for ev in events:
-        ev["start"] = _floor(ev["start"], fps)
-        ev["end"] = _ceil(ev["end"], fps)
-        if ev["end"] <= ev["start"]:
-            ev["end"] = ev["start"] + spf
-
-    prev_end = None
-    for ev in events:
-        lines = (ev.get("text") or "").split("\n")
-        assert len(lines) <= 2, "more than 2 lines"
-        if lines:
-            assert max(len(line) for line in lines) <= max_chars_per_line, "CPL > limit"
-        dur = ev["end"] - ev["start"]
-        assert dur + tolerance >= min_dur, "duration <20f"
-        txt = "".join(lines)
-        cps = len(txt) / max(0.001, dur)
-        assert cps <= cps_target + 1e-6, "cps > limit"
-        if prev_end is not None:
-            gap = ev["start"] - prev_end
-            assert gap >= min_gap_frames*spf - 1e-6, "gap <2f"
-        prev_end = ev["end"]
+    # Re-chain after merges in case new small gaps were introduced
+    for i in range(len(events) - 1):
+        gap = events[i+1]["start"] - events[i]["end"]
+        if gap < small_gap_floor_s:
+            desired = events[i+1]["start"] - min_gap_frames*spf
+            if desired > events[i]["end"]:
+                events[i]["end"] = desired
     return events
 
 # ---------- top-level postprocess ----------


### PR DESCRIPTION
## Summary
- Implement bottom-heavy two-line wrapping and pause-aware segmentation to preserve word timings
- Add orphan-aware packer and enforce Netflix timing rules with safe linger and gap normalization
- Expose Netflix-guideline knobs in CLI for frame-aligned transcription

## Testing
- `pytest -q`
