### PR TITLE
Add guards for overflow loops and packer disable switch

### DIFF
--- a/srt_utils.py
+++ b/srt_utils.py
@@ -81,7 +81,9 @@ def pack_into_two_line_blocks(
         start = float(bw[0]["start"])
         end = float(blk["end"])
         j = i
-        while j+1 < len(events):
+        tries = 0
+        MAX_TRIES = 32  # hard cap per block
+        while j+1 < len(events) and tries < MAX_TRIES:
             gap_ms = int(round((events[j+1]["start"] - events[j]["end"]) * 1000))
             if gap_ms > coalesce_gap_ms: break
             # Do not let the candidate block grow beyond max duration
@@ -89,6 +91,17 @@ def pack_into_two_line_blocks(
             if (cand_end - start) > max_block_duration_s:
                 break
             cw = (events[j+1].get("words") or [])
+            # --- Cheap prefilters before expensive shaping ---
+            if not cw:
+                break
+            # rough char count (no spaces). Allow small slack.
+            naive_chars = sum(len((w.get("word","").strip())) for w in (bw+cw))
+            if naive_chars > (max_chars_per_line*2 + 8):
+                break
+            naive_dur = (events[j+1]["end"] - start) or 1e-3
+            if (naive_chars / naive_dur) > (cps_target * 1.15):
+                break
+            # -------------------------------------------------
             cand = bw + cw
             lines, used, overflow = shaper(
                 cand,
@@ -102,6 +115,7 @@ def pack_into_two_line_blocks(
             cps = len(txt) / max(0.001, (events[j+1]["end"] - start))
             if cps > cps_target: break
             bw = cand; end = float(events[j+1]["end"]); j += 1
+            tries += 1
         lines, used, overflow = shaper(
             bw,
             max_chars=max_chars_per_line,
@@ -217,7 +231,8 @@ def enforce_min_readable_v2(
                     # If overflow exists, emit it as its own event(s)
                     k = i+1
                     cur_over = overflow
-                    while cur_over:
+                    guard = 0
+                    while cur_over and guard < 1000:
                         lines2, used2, over2 = shaper(
                             cur_over,
                             max_chars=max_chars_per_line,
@@ -225,6 +240,11 @@ def enforce_min_readable_v2(
                             two_line_threshold=0.60,
                             min_two_line_chars=min_two_line_chars,
                         )
+                        # Guarantee progress even on pathological tokens (e.g., 60+ char word)
+                        if used2 <= 0:
+                            used2 = 1
+                            lines2 = [normalize_text(cur_over[0].get("word",""))]
+                            over2  = cur_over[1:]
                         used_block2 = cur_over[:used2]
                         events.insert(k, {
                             "start": float(used_block2[0]["start"]),
@@ -234,6 +254,7 @@ def enforce_min_readable_v2(
                         })
                         k += 1
                         cur_over = over2
+                        guard += 1
                     # Remove the original neighbor we merged into
                     del events[k]
                     continue
@@ -258,7 +279,8 @@ def enforce_min_readable_v2(
                     # If overflow exists, emit it as its own event(s)
                     k = i
                     cur_over = overflow
-                    while cur_over:
+                    guard = 0
+                    while cur_over and guard < 1000:
                         lines2, used2, over2 = shaper(
                             cur_over,
                             max_chars=max_chars_per_line,
@@ -266,6 +288,11 @@ def enforce_min_readable_v2(
                             two_line_threshold=0.60,
                             min_two_line_chars=min_two_line_chars,
                         )
+                        # Guarantee progress even on pathological tokens (e.g., 60+ char word)
+                        if used2 <= 0:
+                            used2 = 1
+                            lines2 = [normalize_text(cur_over[0].get("word",""))]
+                            over2  = cur_over[1:]
                         used_block2 = cur_over[:used2]
                         events.insert(k, {
                             "start": float(used_block2[0]["start"]),
@@ -275,6 +302,7 @@ def enforce_min_readable_v2(
                         })
                         k += 1
                         cur_over = over2
+                        guard += 1
                     # Remove the orphan we merged
                     del events[k]
                     i -= 1
@@ -716,17 +744,19 @@ def postprocess_segments(
         two_line_threshold=two_line_threshold,
         min_two_line_chars=min_two_line_chars,
     )
-    # Merge small neighbors into calm 2-line blocks
-    events = pack_into_two_line_blocks(
-        events,
-        max_chars_per_line=max_chars_per_line,
-        cps_target=cps_target,
-        coalesce_gap_ms=coalesce_gap_ms,
-        two_line_threshold=two_line_threshold,
-        min_two_line_chars=min_two_line_chars,
-        max_block_duration_s=max_block_duration_s,
-        shaper=shape_words_into_two_lines_balanced,
-    )
+    # Merge small neighbors into calm 2-line blocks (can be heavy on some inputs)
+    import os
+    if os.environ.get("PARAKEET_DISABLE_PACKER") != "1":
+        events = pack_into_two_line_blocks(
+            events,
+            max_chars_per_line=max_chars_per_line,
+            cps_target=cps_target,
+            coalesce_gap_ms=coalesce_gap_ms,
+            two_line_threshold=two_line_threshold,
+            min_two_line_chars=min_two_line_chars,
+            max_block_duration_s=max_block_duration_s,
+            shaper=shape_words_into_two_lines_balanced,
+        )
     # Eliminate quick singles (orphans) and short flashes
     events = enforce_min_readable_v2(
         events,


### PR DESCRIPTION
## Summary
- Ensure overflow emission loop always makes progress and avoid infinite loops
- Add cheap pre-filters and iteration cap in pack_into_two_line_blocks for better performance
- Allow disabling two-line block packer via `PARAKEET_DISABLE_PACKER` environment variable

## Testing
- `python -m py_compile srt_utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5cffa2994832c8f6328e7fac56fbb