### PR TITLE
Use _merged_words for merges and floor/ceil SRT timestamps

### DIFF
--- a/parakeet_transcribe.py
+++ b/parakeet_transcribe.py
@@ -35,7 +35,7 @@ _ROOT = Path(__file__).resolve().parent
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-from srt_utils import format_time_srt, postprocess_segments, write_srt, normalize_text
+from srt_utils import format_start_ms, format_end_ms, postprocess_segments, write_srt, normalize_text
 
 
 def _audit(events_in, events_out):
@@ -97,7 +97,7 @@ def generate_srt_from_processed_timestamps(
                 end_s = segment_data.get('end_seconds', start_s + 0.1) # Ensure end is after start
                 if not text: continue # Skip empty segments
                 f.write(f"{segment_num}\n")
-                f.write(f"{format_time_srt(start_s)} --> {format_time_srt(end_s)}\n")
+                f.write(f"{format_start_ms(start_s)} --> {format_end_ms(end_s)}\n")
                 f.write(text + "\n\n")
             print(f"SRT file generated from {len(all_processed_timestamps)} segments at '{srt_file_path}'", file=sys.stderr)
 
@@ -112,7 +112,7 @@ def generate_srt_from_processed_timestamps(
                 if not current_words:
                     return
                 f.write(f"{segment_num}\n")
-                f.write(f"{format_time_srt(segment_start)} --> {format_time_srt(final_end)}\n")
+                f.write(f"{format_start_ms(segment_start)} --> {format_end_ms(final_end)}\n")
                 f.write(" ".join(current_words).strip() + "\n\n")
                 segment_num += 1
                 current_words = []

--- a/srt_utils.py
+++ b/srt_utils.py
@@ -39,10 +39,13 @@ SPACES = re.compile(r"\s+")
 def normalize_text(t: str) -> str:
     return SPACES.sub(" ", (t or "")).strip()
 
-def srt_ts(t: float) -> str:
-    if not math.isfinite(t) or t < 0:
-        t = 0.0
-    total_ms = int(round(t * 1000))
+def _ms_floor(t: float) -> int:
+    return 0 if not math.isfinite(t) or t < 0 else math.floor(t * 1000 + 1e-9)
+
+def _ms_ceil(t: float) -> int:
+    return 0 if not math.isfinite(t) or t < 0 else math.ceil(t * 1000 - 1e-9)
+
+def _fmt_ms(total_ms: int) -> str:
     ms = total_ms % 1000
     total_s = total_ms // 1000
     s = total_s % 60
@@ -51,13 +54,13 @@ def srt_ts(t: float) -> str:
     h = total_m // 60
     return f"{h:02}:{m:02}:{s:02},{ms:03}"
 
-def format_time_srt(t: float) -> str:
-    return srt_ts(t)
+def format_start_ms(t: float) -> str: return _fmt_ms(_ms_floor(t))
+def format_end_ms  (t: float) -> str: return _fmt_ms(_ms_ceil (t))
 
 def write_srt(events: List[Dict[str,Any]], out_path: str) -> None:
     with open(out_path, "w", encoding="utf-8") as f:
         for i, ev in enumerate(events, 1):
-            f.write(f"{i}\n{srt_ts(ev['start'])} --> {srt_ts(ev['end'])}\n{ev['text'].strip()}\n\n")
+            f.write(f"{i}\n{format_start_ms(ev['start'])} --> {format_end_ms(ev['end'])}\n{ev['text'].strip()}\n\n")
 
 # helper: cps of an event
 def _cps_of(ev: Dict[str, Any]) -> float:
@@ -260,7 +263,7 @@ def enforce_min_readable_v2(
                 # Only merge forward if the gap is small
                 gap_ms = int(round((nxt["start"] - e["end"]) * 1000))
                 if gap_ms <= max_merge_gap_ms:
-                    cand_words = (e.get("words") or []) + (nxt.get("words") or [])
+                    cand_words = _merged_words(e, nxt)
                     lines, used, overflow = shaper(
                         cand_words,
                         max_chars=max_chars_per_line,
@@ -308,7 +311,7 @@ def enforce_min_readable_v2(
                 # Only merge backward if the gap is small
                 gap_ms = int(round((e["start"] - prev["end"]) * 1000))
                 if gap_ms <= max_merge_gap_ms:
-                    cand_words = (prev.get("words") or []) + (e.get("words") or [])
+                    cand_words = _merged_words(prev, e)
                     lines, used, overflow = shaper(
                         cand_words,
                         max_chars=max_chars_per_line,

--- a/tests/test_format_time_srt.py
+++ b/tests/test_format_time_srt.py
@@ -4,17 +4,18 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from srt_utils import format_time_srt
+from srt_utils import format_start_ms, format_end_ms
 
-class TestFormatTimeSrt(unittest.TestCase):
-    def test_rounding_carries_seconds(self):
-        self.assertEqual(format_time_srt(1.9996), "00:00:02,000")
-    def test_negative_value_clamped(self):
-        self.assertEqual(format_time_srt(-5.0), "00:00:00,000")
-    def test_nan_value_clamped(self):
-        self.assertEqual(format_time_srt(float('nan')), "00:00:00,000")
-    def test_infinite_value_clamped(self):
-        self.assertEqual(format_time_srt(float('inf')), "00:00:00,000")
+class TestFormatMs(unittest.TestCase):
+    def test_start_floor(self):
+        self.assertEqual(format_start_ms(1.9996), "00:00:01,999")
+
+    def test_end_ceil(self):
+        self.assertEqual(format_end_ms(1.9994), "00:00:02,000")
+
+    def test_clamp_invalid(self):
+        self.assertEqual(format_start_ms(-5.0), "00:00:00,000")
+        self.assertEqual(format_end_ms(float('nan')), "00:00:00,000")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- bias SRT time formatting to floor starts and ceil ends to preserve visible 2-frame gaps
- replace manual word concatenations with `_merged_words` to avoid dropping tokens
- update CLI and tests for new timestamp helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c6b251f5ec832caa1e1e01973c52f7