### PR TITLE
Store temporary outputs in parakeet_runs

### DIFF
--- a/parakeet_caption.lua
+++ b/parakeet_caption.lua
@@ -61,6 +61,8 @@ local ffprobe_path = "ffprobe"
 -- @example "/tmp/mpv_parakeet_audio"
 local temp_dir = "C:/Users/mrkun/AppData/Local/Temp/parakeet_runs"
 
+math.randomseed(os.time() + math.floor((mp.get_time() or 0) * 1000) % 1000)
+
 -- Keybindings for different transcription modes.
 local key_binding_default = "Alt+4"             -- Standard transcription (no FFmpeg preprocessing, default Python precision)
 local key_binding_py_float32 = "Alt+5"          -- Python Float32 precision (no FFmpeg preprocessing)
@@ -223,6 +225,40 @@ local function safe_remove(filepath, description)
     else
         log("debug", "Temporary file (" .. (description or "unspecified") .. ") not found for removal, skipping: ", filepath)
     end
+end
+
+local function ensure_directory(path)
+    if not path or path == "" then return false end
+    local info = utils.file_info(path)
+    if info and info.is_dir then return true end
+    local cmd
+    if package.config:sub(1,1) == '\\' then
+        if path:match("^[A-Za-z]:$") then
+            return false
+        end
+        local win_path = path:gsub("/", "\\")
+        cmd = string.format('cmd /C "if not exist "%s" mkdir "%s""', win_path, win_path)
+    else
+        cmd = string.format('mkdir -p "%s"', path)
+    end
+    local ok, _, code = os.execute(cmd)
+    if type(ok) == "number" then
+        return ok == 0
+    end
+    if type(ok) == "boolean" then
+        return ok
+    end
+    return code == 0
+end
+
+local function allocate_run_directory()
+    local stamp = os.date("%Y%m%d-%H%M%S")
+    local suffix = string.format("%08x", math.random(0, 0xffffffff))
+    local run_dir = utils.join_path(temp_dir, stamp .. "_" .. suffix)
+    if ensure_directory(run_dir) then
+        return run_dir
+    end
+    return nil
 end
 
 local function select_existing_or_add(srt_path, want_reload)
@@ -449,6 +485,14 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
         return
     end
 
+    local run_dir = allocate_run_directory()
+    if not run_dir then
+        log("error", "Failed to create run directory inside '", temp_dir, "'.")
+        abort()
+        return
+    end
+    log("info", "Using run temp directory: ", run_dir)
+
     local current_media_path = mp.get_property_native("path")
     if not current_media_path or current_media_path == "" then
         log("error", "No media file is currently playing.")
@@ -474,7 +518,7 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
     local srt_output_path = utils.join_path(media_dir, base_name .. ".srt") -- SRT next to media
     local sanitized_base_name = base_name:gsub("[^%w%-_%.]", "_") -- Sanitize for temp file names
 
-    local temp_audio_raw_path = utils.join_path(temp_dir, sanitized_base_name .. "_audio_raw.wav")
+    local temp_audio_raw_path = utils.join_path(run_dir, sanitized_base_name .. "_audio_raw.wav")
     local temp_audio_for_python = temp_audio_raw_path -- This will be the input to Python
 
     -- Ensure raw temp audio path is scheduled for cleanup, regardless of success/failure later
@@ -580,7 +624,7 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
     log("info", "FFmpeg raw audio extraction successful: ", temp_audio_raw_path)
 
     if apply_ffmpeg_filters_flag then
-        temp_audio_for_python = utils.join_path(temp_dir, sanitized_base_name .. "_audio_filtered.wav")
+        temp_audio_for_python = utils.join_path(run_dir, sanitized_base_name .. "_audio_filtered.wav")
         if temp_audio_raw_path ~= temp_audio_for_python then
              table.insert(files_to_cleanup_on_shutdown, temp_audio_for_python)
         end
@@ -657,6 +701,9 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
       playback_only = false,
       capture_stdout = false,
       capture_stderr = false,
+      env = {
+        PARAKEET_LOG_FILE = utils.join_path(run_dir, "run.log"),
+      },
     }, function(success, res, err)
       local rc = (res and res.status) or -1
       if not success or rc ~= 0 then
@@ -701,6 +748,14 @@ local function run_isolate_then_asr(model)
         return
     end
 
+    local run_dir = allocate_run_directory()
+    if not run_dir then
+        log("error", "Failed to create run directory inside '", temp_dir, "'.")
+        abort()
+        return
+    end
+    log("info", "Using run temp directory: ", run_dir)
+
     local current_media_path = mp.get_property_native("path")
     if not current_media_path or current_media_path == "" then
         log("error", "No media file is currently playing.")
@@ -725,9 +780,9 @@ local function run_isolate_then_asr(model)
     local sanitized_base_name = base_name:gsub("[^%w%-_%.]", "_")
 
     -- temp_stereo retains source sample rate (no pre-resample)
-    local temp_stereo = utils.join_path(temp_dir, sanitized_base_name .. "_stereo_44k.wav")
-    local temp_vocals_44k = utils.join_path(temp_dir, sanitized_base_name .. "_vocals_44k.wav")
-    local temp_vocals_16k = utils.join_path(temp_dir, sanitized_base_name .. "_vocals_16k.wav")
+    local temp_stereo = utils.join_path(run_dir, sanitized_base_name .. "_stereo_44k.wav")
+    local temp_vocals_44k = utils.join_path(run_dir, sanitized_base_name .. "_vocals_44k.wav")
+    local temp_vocals_16k = utils.join_path(run_dir, sanitized_base_name .. "_vocals_16k.wav")
     table.insert(files_to_cleanup_on_shutdown, temp_stereo)
     table.insert(files_to_cleanup_on_shutdown, temp_vocals_44k)
     table.insert(files_to_cleanup_on_shutdown, temp_vocals_16k)
@@ -848,6 +903,9 @@ local function run_isolate_then_asr(model)
       playback_only = false,
       capture_stdout = false,
       capture_stderr = false,
+      env = {
+        PARAKEET_LOG_FILE = utils.join_path(run_dir, "run.log"),
+      },
     }
     local initial_stat = _stat(srt_output_path)
     attach_when_ready(srt_output_path, {
@@ -924,7 +982,7 @@ log("info", "Using Python from: ", python_exe)
 log("info", "Using FFmpeg from: ", ffmpeg_path)
 log("info", "Using FFprobe from: ", ffprobe_path)
 log("info", "Parakeet script: ", parakeet_script_path)
-log("info", "Temporary file directory: ", temp_dir)
+log("info", "Temporary file root directory: ", temp_dir)
 log("info", "FFmpeg pre-processing filters: ", ffmpeg_audio_filters)
 
 --- Event handler for MPV's "shutdown" event.

--- a/parakeet_caption.lua
+++ b/parakeet_caption.lua
@@ -10,6 +10,8 @@ local mp = require 'mp'
 local utils = require 'mp.utils'
 local msg   = mp.msg
 
+local IS_WINDOWS = package.config:sub(1,1) == '\\'
+
 local osd_duration_default = 3 -- seconds
 
 -- Subtitle alignment and styling are configured via mpv.conf;
@@ -151,26 +153,36 @@ end
 -- This block checks for the existence of `temp_dir`. If not found, it tries
 -- to create it using OS-specific commands. Warnings are logged if creation fails
 -- or if `temp_dir` points to a root drive on Windows (which `mkdir` cannot create).
+local function run_mkdir(path)
+    if not path or path == "" then return false end
+    local args
+    if IS_WINDOWS then
+        if path:match("^[A-Za-z]:$") then
+            mp.msg.warn("[parakeet_mpv] Cannot 'mkdir' a root drive like '" .. path .. "'.")
+            return false
+        end
+        local win_path = path:gsub("/", "\\")
+        args = {"cmd.exe", "/C", string.format('if not exist "%s" mkdir "%s"', win_path, win_path)}
+    else
+        args = {"mkdir", "-p", path}
+    end
+    local res = utils.subprocess({
+        args = args,
+        cancellable = false,
+        capture_stdout = false,
+        capture_stderr = false,
+    })
+    if not res then return false end
+    if res.error or res.status ~= 0 then return false end
+    return true
+end
+
 if not utils.file_info(temp_dir) then
     mp.msg.warn("[parakeet_mpv] Temporary directory does not exist: " .. temp_dir)
-    local mkdir_cmd
-    if package.config:sub(1,1) == '\\' then -- Windows OS
-        if temp_dir:match("^[A-Za-z]:$") then -- Check if it's a root drive like C:
-            mp.msg.warn("[parakeet_mpv] Cannot 'mkdir' a root drive like '" .. temp_dir .. "'. Please ensure it's accessible and not a root drive itself for mkdir.")
-        else
-            -- For Windows, use cmd /C to handle spaces in paths correctly for mkdir
-            mkdir_cmd = string.format('cmd /C "if not exist "%s" mkdir "%s""', temp_dir:gsub("/", "\\"), temp_dir:gsub("/", "\\"))
-            local _, err_code = os.execute(mkdir_cmd)
-            if err_code == 0 then
-                mp.msg.info("[parakeet_mpv] Attempted to create temp directory: " .. temp_dir)
-            else
-                mp.msg.warn("[parakeet_mpv] Failed to create temp directory. Exit Code: " .. to_str_safe(err_code))
-            end
-        end
-    else -- Linux/macOS
-        mkdir_cmd = string.format('mkdir -p "%s"', temp_dir)
-        os.execute(mkdir_cmd)
+    if run_mkdir(temp_dir) then
         mp.msg.info("[parakeet_mpv] Attempted to create temp directory: " .. temp_dir)
+    else
+        mp.msg.warn("[parakeet_mpv] Failed to create temp directory via subprocess.")
     end
 end
 
@@ -205,23 +217,10 @@ local function ensure_directory(path)
     local info = utils.file_info(path)
     if info and info.is_dir then return true end
     local cmd
-    if package.config:sub(1,1) == '\\' then
-        if path:match("^[A-Za-z]:$") then
-            return false
-        end
-        local win_path = path:gsub("/", "\\")
-        cmd = string.format('cmd /C "if not exist "%s" mkdir "%s""', win_path, win_path)
-    else
-        cmd = string.format('mkdir -p "%s"', path)
+    if IS_WINDOWS and path:match("^[A-Za-z]:$") then
+        return false
     end
-    local ok, _, code = os.execute(cmd)
-    if type(ok) == "number" then
-        return ok == 0
-    end
-    if type(ok) == "boolean" then
-        return ok
-    end
-    return code == 0
+    return run_mkdir(path)
 end
 
 local function allocate_run_directory()

--- a/parakeet_caption.lua
+++ b/parakeet_caption.lua
@@ -104,13 +104,6 @@ local seg_args = { "--segmenter","word","--max_words","12","--max_duration","6.0
 local ffmpeg_audio_filters = "loudnorm=I=-16:LRA=7:TP=-1.5"
 -- ###################################
 
---- Table to store paths of temporary files for cleanup on MPV shutdown.
--- When temporary audio files are created, their paths are added to this table.
--- The `mp.register_event("shutdown", ...)` function iterates through this table
--- to remove these files when MPV closes.
--- @type table<string>
-local files_to_cleanup_on_shutdown = {}
-
 --- Flag to prevent concurrent transcription runs.
 -- When true, additional transcription requests are ignored until completion.
 -- @type boolean
@@ -204,26 +197,6 @@ local function log(level, ...)
     if level == "error" then mp.osd_message("Parakeet Error: " .. message, 7) -- Duration 7 seconds
     elseif level == "warn" then mp.osd_message("Parakeet Warning: " .. message, 5) -- Duration 5 seconds
     elseif level == "info" then mp.osd_message("Parakeet: " .. message, 3) -- Duration 3 seconds
-    end
-end
-
---- Safely removes a file from the filesystem.
--- Checks if the file exists before attempting removal. Logs the action (success or failure)
--- using the `log` function at "debug" or "warn" level.
--- @param filepath string The path to the file to be removed. If `nil`, the function returns immediately.
--- @param description string (optional) A description of the file for logging purposes (e.g., "raw audio", "filtered audio"). Defaults to "unspecified".
--- @usage safe_remove("/path/to/temp.wav", "temporary audio")
-local function safe_remove(filepath, description)
-    if not filepath then return end
-    if utils.file_info(filepath) then
-        local success, err_msg = os.remove(filepath)
-        if success then
-            log("debug", "Cleaned up temporary file (" .. (description or "unspecified") .. "): ", filepath)
-        else
-            log("warn", "Failed to remove temporary file (" .. (description or "unspecified") .. "): ", filepath, " - Error: ", (err_msg or "unknown"))
-        end
-    else
-        log("debug", "Temporary file (" .. (description or "unspecified") .. ") not found for removal, skipping: ", filepath)
     end
 end
 
@@ -438,7 +411,6 @@ end
 -- 6. Invokes the `parakeet_transcribe.py` script with the appropriate temporary audio file and parameters (including start offset and float32 flag).
 -- 7. Attempts to load the generated SRT subtitle file into MPV using `sub-add` with the `select` flag to make it active.
 -- 8. Logs progress and errors, displaying OSD messages for user feedback.
--- Temporary audio files created during this process are added to `files_to_cleanup_on_shutdown`.
 --
 -- @param force_python_float32_flag boolean If `true`, the "--force_float32" argument is passed to
 -- the `parakeet_transcribe.py` script, potentially changing its processing precision.
@@ -522,7 +494,6 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
     local temp_audio_for_python = temp_audio_raw_path -- This will be the input to Python
 
     -- Ensure raw temp audio path is scheduled for cleanup, regardless of success/failure later
-    table.insert(files_to_cleanup_on_shutdown, temp_audio_raw_path)
 
     local mode_description = "Standard (Alt+4)"
     if force_python_float32_flag and apply_ffmpeg_filters_flag then mode_description = "FFmpeg Preproc + Python Float32 (Alt+7)"
@@ -626,7 +597,6 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
     if apply_ffmpeg_filters_flag then
         temp_audio_for_python = utils.join_path(run_dir, sanitized_base_name .. "_audio_filtered.wav")
         if temp_audio_raw_path ~= temp_audio_for_python then
-             table.insert(files_to_cleanup_on_shutdown, temp_audio_for_python)
         end
         log("info", "Step 1.5: Applying FFmpeg audio filters: ", ffmpeg_audio_filters)
         mp.osd_message("Parakeet: Applying FFmpeg audio filters...", 5)
@@ -702,7 +672,7 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
       capture_stdout = false,
       capture_stderr = false,
       env = {
-        PARAKEET_LOG_FILE = utils.join_path(run_dir, "run.log"),
+        string.format("PARAKEET_LOG_FILE=%s", utils.join_path(run_dir, "run.log")),
       },
     }, function(success, res, err)
       local rc = (res and res.status) or -1
@@ -783,9 +753,6 @@ local function run_isolate_then_asr(model)
     local temp_stereo = utils.join_path(run_dir, sanitized_base_name .. "_stereo_44k.wav")
     local temp_vocals_44k = utils.join_path(run_dir, sanitized_base_name .. "_vocals_44k.wav")
     local temp_vocals_16k = utils.join_path(run_dir, sanitized_base_name .. "_vocals_16k.wav")
-    table.insert(files_to_cleanup_on_shutdown, temp_stereo)
-    table.insert(files_to_cleanup_on_shutdown, temp_vocals_44k)
-    table.insert(files_to_cleanup_on_shutdown, temp_vocals_16k)
 
     local audio_offset_seconds, audio_stream_idx = get_audio_stream_info(current_media_path, "eng")
     if not audio_offset_seconds then audio_offset_seconds = 0.0 end
@@ -904,7 +871,7 @@ local function run_isolate_then_asr(model)
       capture_stdout = false,
       capture_stderr = false,
       env = {
-        PARAKEET_LOG_FILE = utils.join_path(run_dir, "run.log"),
+        string.format("PARAKEET_LOG_FILE=%s", utils.join_path(run_dir, "run.log")),
       },
     }
     local initial_stat = _stat(srt_output_path)
@@ -971,7 +938,7 @@ mp.add_forced_key_binding(key_binding_isolate_asr_slow, "parakeet_slow", functio
 
 log("info", "Parakeet (Multi-Mode) script loaded.")
 log("info", "SRT will be loaded immediately after transcription and selected.")
-log("info", "Temporary files will be cleaned up on MPV shutdown.")
+log("info", "Temporary files are retained in the Parakeet run directory for later review.")
 log("info", "Press '", key_binding_default, "' for Standard Transcription.")
 log("info", "Press '", key_binding_py_float32, "' for Python Float32 Precision.")
 log("info", "Press '", key_binding_ffmpeg_preprocess, "' for FFmpeg Preprocessing (Default Python Precision).")
@@ -986,20 +953,9 @@ log("info", "Temporary file root directory: ", temp_dir)
 log("info", "FFmpeg pre-processing filters: ", ffmpeg_audio_filters)
 
 --- Event handler for MPV's "shutdown" event.
--- This function is called when MPV is closing. It iterates through the
--- `files_to_cleanup_on_shutdown` table and attempts to remove each file
--- listed, using `safe_remove` to handle errors and logging.
--- After attempting cleanup, the `files_to_cleanup_on_shutdown` table is cleared.
+-- Leave per-run artifacts intact so Python-side cleanup can purge old runs.
 mp.register_event("shutdown", function()
-    log("info", "MPV shutdown event. Cleaning up temporary Parakeet files...")
-    if #files_to_cleanup_on_shutdown > 0 then
-        for _, filepath in ipairs(files_to_cleanup_on_shutdown) do
-            safe_remove(filepath, "Shutdown cleanup")
-        end
-        files_to_cleanup_on_shutdown = {} -- Clear the table after attempting cleanup
-    else
-        log("info", "No temporary files registered for cleanup.")
-    end
+    log("info", "MPV shutdown event. Parakeet run artifacts remain available under the temp root.")
     if attach_timer then attach_timer:kill(); attach_timer = nil end
-    log("info", "Parakeet shutdown cleanup finished.")
+    log("info", "Parakeet shutdown handling finished.")
 end)

--- a/parakeet_caption.lua
+++ b/parakeet_caption.lua
@@ -59,7 +59,7 @@ local ffprobe_path = "ffprobe"
 -- @type string
 -- @example "C:/temp_audio_mpv"
 -- @example "/tmp/mpv_parakeet_audio"
-local temp_dir = "C:/temp"
+local temp_dir = "C:/Users/mrkun/AppData/Local/Temp/parakeet_runs"
 
 -- Keybindings for different transcription modes.
 local key_binding_default = "Alt+4"             -- Standard transcription (no FFmpeg preprocessing, default Python precision)

--- a/parakeet_caption_for_JellyfinMpvShim.lua
+++ b/parakeet_caption_for_JellyfinMpvShim.lua
@@ -9,6 +9,8 @@
 local mp = require 'mp'
 local utils = require 'mp.utils'
 
+local IS_WINDOWS = package.config:sub(1,1) == '\\'
+
 -- Subtitle alignment and styling are configured via mpv.conf;
 -- this script intentionally avoids forcing ASS overrides.
 
@@ -125,26 +127,36 @@ end
 -- This block checks for the existence of `temp_dir`. If not found, it tries
 -- to create it using OS-specific commands. Warnings are logged if creation fails
 -- or if `temp_dir` points to a root drive on Windows (which `mkdir` cannot create).
+local function run_mkdir(path)
+    if not path or path == "" then return false end
+    local args
+    if IS_WINDOWS then
+        if path:match("^[A-Za-z]:$") then
+            mp.msg.warn("[parakeet_mpv] Cannot 'mkdir' a root drive like '" .. path .. "'.")
+            return false
+        end
+        local win_path = path:gsub("/", "\\")
+        args = {"cmd.exe", "/C", string.format('if not exist "%s" mkdir "%s"', win_path, win_path)}
+    else
+        args = {"mkdir", "-p", path}
+    end
+    local res = utils.subprocess({
+        args = args,
+        cancellable = false,
+        capture_stdout = false,
+        capture_stderr = false,
+    })
+    if not res then return false end
+    if res.error or res.status ~= 0 then return false end
+    return true
+end
+
 if not utils.file_info(temp_dir) then
     mp.msg.warn("[parakeet_mpv] Temporary directory does not exist: " .. temp_dir)
-    local mkdir_cmd
-    if package.config:sub(1,1) == '\\' then -- Windows OS
-        if temp_dir:match("^[A-Za-z]:$") then -- Check if it's a root drive like C:
-            mp.msg.warn("[parakeet_mpv] Cannot 'mkdir' a root drive like '" .. temp_dir .. "'. Please ensure it's accessible and not a root drive itself for mkdir.")
-        else
-            -- For Windows, use cmd /C to handle spaces in paths correctly for mkdir
-            mkdir_cmd = string.format('cmd /C "if not exist "%s" mkdir "%s""', temp_dir:gsub("/", "\\"), temp_dir:gsub("/", "\\"))
-            local _, err_code = os.execute(mkdir_cmd)
-            if err_code == 0 then
-                mp.msg.info("[parakeet_mpv] Attempted to create temp directory: " .. temp_dir)
-            else
-                mp.msg.warn("[parakeet_mpv] Failed to create temp directory. Exit Code: " .. to_str_safe(err_code))
-            end
-        end
-    else -- Linux/macOS
-        mkdir_cmd = string.format('mkdir -p "%s"', temp_dir)
-        os.execute(mkdir_cmd)
+    if run_mkdir(temp_dir) then
         mp.msg.info("[parakeet_mpv] Attempted to create temp directory: " .. temp_dir)
+    else
+        mp.msg.warn("[parakeet_mpv] Failed to create temp directory via subprocess.")
     end
 end
 
@@ -179,23 +191,10 @@ local function ensure_directory(path)
     local info = utils.file_info(path)
     if info and info.is_dir then return true end
     local cmd
-    if package.config:sub(1,1) == '\\' then
-        if path:match("^[A-Za-z]:$") then
-            return false
-        end
-        local win_path = path:gsub("/", "\\")
-        cmd = string.format('cmd /C "if not exist "%s" mkdir "%s""', win_path, win_path)
-    else
-        cmd = string.format('mkdir -p "%s"', path)
+    if IS_WINDOWS and path:match("^[A-Za-z]:$") then
+        return false
     end
-    local ok, _, code = os.execute(cmd)
-    if type(ok) == "number" then
-        return ok == 0
-    end
-    if type(ok) == "boolean" then
-        return ok
-    end
-    return code == 0
+    return run_mkdir(path)
 end
 
 local function allocate_run_directory()

--- a/parakeet_caption_for_JellyfinMpvShim.lua
+++ b/parakeet_caption_for_JellyfinMpvShim.lua
@@ -58,6 +58,8 @@ local ffprobe_path = "ffprobe"
 -- @example "/tmp/mpv_parakeet_audio"
 local temp_dir = "C:/Users/mrkun/AppData/Local/Temp/parakeet_runs"
 
+math.randomseed(os.time() + math.floor((mp.get_time() or 0) * 1000) % 1000)
+
 -- Keybindings for different transcription modes.
 local key_binding_default = "Alt+4"             -- Standard transcription (no FFmpeg preprocessing, default Python precision)
 local key_binding_py_float32 = "Alt+5"          -- Python Float32 precision (no FFmpeg preprocessing)
@@ -197,6 +199,40 @@ local function safe_remove(filepath, description)
     else
         log("debug", "Temporary file (" .. (description or "unspecified") .. ") not found for removal, skipping: ", filepath)
     end
+end
+
+local function ensure_directory(path)
+    if not path or path == "" then return false end
+    local info = utils.file_info(path)
+    if info and info.is_dir then return true end
+    local cmd
+    if package.config:sub(1,1) == '\\' then
+        if path:match("^[A-Za-z]:$") then
+            return false
+        end
+        local win_path = path:gsub("/", "\\")
+        cmd = string.format('cmd /C "if not exist "%s" mkdir "%s""', win_path, win_path)
+    else
+        cmd = string.format('mkdir -p "%s"', path)
+    end
+    local ok, _, code = os.execute(cmd)
+    if type(ok) == "number" then
+        return ok == 0
+    end
+    if type(ok) == "boolean" then
+        return ok
+    end
+    return code == 0
+end
+
+local function allocate_run_directory()
+    local stamp = os.date("%Y%m%d-%H%M%S")
+    local suffix = string.format("%08x", math.random(0, 0xffffffff))
+    local run_dir = utils.join_path(temp_dir, stamp .. "_" .. suffix)
+    if ensure_directory(run_dir) then
+        return run_dir
+    end
+    return nil
 end
 
 --- Determines if a media path points to a remote resource (e.g., HTTP/HTTPS).
@@ -339,6 +375,14 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
         return
     end
 
+    local run_dir = allocate_run_directory()
+    if not run_dir then
+        log("error", "Failed to create run directory inside '", temp_dir, "'.")
+        abort()
+        return
+    end
+    log("info", "Using run temp directory: ", run_dir)
+
     local current_media_path = mp.get_property_native("path")
     if not current_media_path or current_media_path == "" then
         log("error", "No media file is currently playing.")
@@ -370,7 +414,7 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
         srt_output_path = utils.join_path(media_dir, base_name .. ".srt") -- SRT next to media
     end
 
-    local temp_audio_raw_path = utils.join_path(temp_dir, sanitized_base_name .. "_audio_raw.wav")
+    local temp_audio_raw_path = utils.join_path(run_dir, sanitized_base_name .. "_audio_raw.wav")
     local temp_audio_for_python = temp_audio_raw_path -- This will be the input to Python
 
     -- Ensure raw temp audio path is scheduled for cleanup, regardless of success/failure later
@@ -476,7 +520,7 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
     log("info", "FFmpeg raw audio extraction successful: ", temp_audio_raw_path)
 
     if apply_ffmpeg_filters_flag then
-        temp_audio_for_python = utils.join_path(temp_dir, sanitized_base_name .. "_audio_filtered.wav")
+        temp_audio_for_python = utils.join_path(run_dir, sanitized_base_name .. "_audio_filtered.wav")
         if temp_audio_raw_path ~= temp_audio_for_python then
              table.insert(files_to_cleanup_on_shutdown, temp_audio_for_python)
         end
@@ -536,7 +580,15 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
     table.insert(python_command_args, "--fps=" .. string.format("%.3f", fps))
 
     log("debug", "Running Python script: ", table.concat(python_command_args, " "))
-    local python_res = utils.subprocess({ args = python_command_args, cancellable = false, capture_stdout = true, capture_stderr = true })
+    local python_res = utils.subprocess({
+        args = python_command_args,
+        cancellable = false,
+        capture_stdout = true,
+        capture_stderr = true,
+        env = {
+            PARAKEET_LOG_FILE = utils.join_path(run_dir, "run.log"),
+        },
+    })
 
     if python_res.error then
         log("error", "Failed to launch Parakeet Python script: ", (python_res.error or "Unknown error"))
@@ -603,6 +655,14 @@ local function run_isolate_then_asr(model)
         return
     end
 
+    local run_dir = allocate_run_directory()
+    if not run_dir then
+        log("error", "Failed to create run directory inside '", temp_dir, "'.")
+        abort()
+        return
+    end
+    log("info", "Using run temp directory: ", run_dir)
+
     local current_media_path = mp.get_property_native("path")
     if not current_media_path or current_media_path == "" then
         log("error", "No media file is currently playing.")
@@ -633,8 +693,8 @@ local function run_isolate_then_asr(model)
     end
 
     -- temp_stereo retains source sample rate (no pre-resample)
-    local temp_stereo = utils.join_path(temp_dir, sanitized_base_name .. "_stereo.wav")
-    local temp_vocals = utils.join_path(temp_dir, sanitized_base_name .. "_vocals_16k_mono.wav")
+    local temp_stereo = utils.join_path(run_dir, sanitized_base_name .. "_stereo.wav")
+    local temp_vocals = utils.join_path(run_dir, sanitized_base_name .. "_vocals_16k_mono.wav")
     table.insert(files_to_cleanup_on_shutdown, temp_stereo)
     table.insert(files_to_cleanup_on_shutdown, temp_vocals)
 
@@ -717,7 +777,15 @@ local function run_isolate_then_asr(model)
     for _,v in ipairs(seg_args) do table.insert(parakeet_args, v) end
     local fps = mp.get_property_native("container-fps") or mp.get_property_native("fps") or 24
     table.insert(parakeet_args, "--fps=" .. string.format("%.3f", fps))
-    local python_opts = { args = parakeet_args, cancellable = false, capture_stdout = true, capture_stderr = true }
+    local python_opts = {
+        args = parakeet_args,
+        cancellable = false,
+        capture_stdout = true,
+        capture_stderr = true,
+        env = {
+            PARAKEET_LOG_FILE = utils.join_path(run_dir, "run.log"),
+        },
+    }
     local python_res = utils.subprocess(python_opts)
     if python_res.error then
         log("error", "Failed to launch Parakeet Python script: ", to_str_safe(python_res.error))
@@ -792,7 +860,7 @@ log("info", "Using Python from: ", python_exe)
 log("info", "Using FFmpeg from: ", ffmpeg_path)
 log("info", "Using FFprobe from: ", ffprobe_path)
 log("info", "Parakeet script: ", parakeet_script_path)
-log("info", "Temporary file directory: ", temp_dir)
+log("info", "Temporary file root directory: ", temp_dir)
 log("info", "FFmpeg pre-processing filters: ", ffmpeg_audio_filters)
 
 --- Event handler for MPV's "shutdown" event.

--- a/parakeet_caption_for_JellyfinMpvShim.lua
+++ b/parakeet_caption_for_JellyfinMpvShim.lua
@@ -56,7 +56,7 @@ local ffprobe_path = "ffprobe"
 -- @type string
 -- @example "C:/temp_audio_mpv"
 -- @example "/tmp/mpv_parakeet_audio"
-local temp_dir = "C:/temp"
+local temp_dir = "C:/Users/mrkun/AppData/Local/Temp/parakeet_runs"
 
 -- Keybindings for different transcription modes.
 local key_binding_default = "Alt+4"             -- Standard transcription (no FFmpeg preprocessing, default Python precision)

--- a/parakeet_caption_for_JellyfinMpvShim.lua
+++ b/parakeet_caption_for_JellyfinMpvShim.lua
@@ -101,13 +101,6 @@ local seg_args = { "--segmenter","word","--max_words","12","--max_duration","6.0
 local ffmpeg_audio_filters = "loudnorm=I=-16:LRA=7:TP=-1.5"
 -- ###################################
 
---- Table to store paths of temporary files for cleanup on MPV shutdown.
--- When temporary audio files are created, their paths are added to this table.
--- The `mp.register_event("shutdown", ...)` function iterates through this table
--- to remove these files when MPV closes.
--- @type table<string>
-local files_to_cleanup_on_shutdown = {}
-
 --- Flag to prevent concurrent transcription runs.
 -- When true, additional transcription requests are ignored until completion.
 -- @type boolean
@@ -178,26 +171,6 @@ local function log(level, ...)
     if level == "error" then mp.osd_message("Parakeet Error: " .. message, 7) -- Duration 7 seconds
     elseif level == "warn" then mp.osd_message("Parakeet Warning: " .. message, 5) -- Duration 5 seconds
     elseif level == "info" then mp.osd_message("Parakeet: " .. message, 3) -- Duration 3 seconds
-    end
-end
-
---- Safely removes a file from the filesystem.
--- Checks if the file exists before attempting removal. Logs the action (success or failure)
--- using the `log` function at "debug" or "warn" level.
--- @param filepath string The path to the file to be removed. If `nil`, the function returns immediately.
--- @param description string (optional) A description of the file for logging purposes (e.g., "raw audio", "filtered audio"). Defaults to "unspecified".
--- @usage safe_remove("/path/to/temp.wav", "temporary audio")
-local function safe_remove(filepath, description)
-    if not filepath then return end
-    if utils.file_info(filepath) then
-        local success, err_msg = os.remove(filepath)
-        if success then
-            log("debug", "Cleaned up temporary file (" .. (description or "unspecified") .. "): ", filepath)
-        else
-            log("warn", "Failed to remove temporary file (" .. (description or "unspecified") .. "): ", filepath, " - Error: ", (err_msg or "unknown"))
-        end
-    else
-        log("debug", "Temporary file (" .. (description or "unspecified") .. ") not found for removal, skipping: ", filepath)
     end
 end
 
@@ -328,7 +301,6 @@ end
 -- 6. Invokes the `parakeet_transcribe.py` script with the appropriate temporary audio file and parameters (including start offset and float32 flag).
 -- 7. Attempts to load the generated SRT subtitle file into MPV using `sub-add` with the `select` flag to make it active.
 -- 8. Logs progress and errors, displaying OSD messages for user feedback.
--- Temporary audio files created during this process are added to `files_to_cleanup_on_shutdown`.
 --
 -- @param force_python_float32_flag boolean If `true`, the "--force_float32" argument is passed to
 -- the `parakeet_transcribe.py` script, potentially changing its processing precision.
@@ -418,7 +390,6 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
     local temp_audio_for_python = temp_audio_raw_path -- This will be the input to Python
 
     -- Ensure raw temp audio path is scheduled for cleanup, regardless of success/failure later
-    table.insert(files_to_cleanup_on_shutdown, temp_audio_raw_path)
 
     local mode_description = "Standard (Alt+4)"
     if force_python_float32_flag and apply_ffmpeg_filters_flag then mode_description = "FFmpeg Preproc + Python Float32 (Alt+7)"
@@ -522,7 +493,6 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
     if apply_ffmpeg_filters_flag then
         temp_audio_for_python = utils.join_path(run_dir, sanitized_base_name .. "_audio_filtered.wav")
         if temp_audio_raw_path ~= temp_audio_for_python then
-             table.insert(files_to_cleanup_on_shutdown, temp_audio_for_python)
         end
         log("info", "Step 1.5: Applying FFmpeg audio filters: ", ffmpeg_audio_filters)
         mp.osd_message("Parakeet: Applying FFmpeg audio filters...", 5)
@@ -586,7 +556,7 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
         capture_stdout = true,
         capture_stderr = true,
         env = {
-            PARAKEET_LOG_FILE = utils.join_path(run_dir, "run.log"),
+            string.format("PARAKEET_LOG_FILE=%s", utils.join_path(run_dir, "run.log")),
         },
     })
 
@@ -695,8 +665,6 @@ local function run_isolate_then_asr(model)
     -- temp_stereo retains source sample rate (no pre-resample)
     local temp_stereo = utils.join_path(run_dir, sanitized_base_name .. "_stereo.wav")
     local temp_vocals = utils.join_path(run_dir, sanitized_base_name .. "_vocals_16k_mono.wav")
-    table.insert(files_to_cleanup_on_shutdown, temp_stereo)
-    table.insert(files_to_cleanup_on_shutdown, temp_vocals)
 
     local audio_offset_seconds, audio_stream_idx = get_audio_stream_info(current_media_path, "eng")
     if not audio_offset_seconds then audio_offset_seconds = 0.0 end
@@ -783,7 +751,7 @@ local function run_isolate_then_asr(model)
         capture_stdout = true,
         capture_stderr = true,
         env = {
-            PARAKEET_LOG_FILE = utils.join_path(run_dir, "run.log"),
+            string.format("PARAKEET_LOG_FILE=%s", utils.join_path(run_dir, "run.log")),
         },
     }
     local python_res = utils.subprocess(python_opts)
@@ -849,7 +817,7 @@ mp.add_forced_key_binding(key_binding_isolate_asr_slow, "parakeet_slow", functio
 
 log("info", "Parakeet (Multi-Mode) script loaded.")
 log("info", "SRT will be loaded immediately after transcription and selected.")
-log("info", "Temporary files will be cleaned up on MPV shutdown.")
+log("info", "Temporary files are retained in the Parakeet run directory for later review.")
 log("info", "Press '", key_binding_default, "' for Standard Transcription.")
 log("info", "Press '", key_binding_py_float32, "' for Python Float32 Precision.")
 log("info", "Press '", key_binding_ffmpeg_preprocess, "' for FFmpeg Preprocessing (Default Python Precision).")
@@ -864,19 +832,9 @@ log("info", "Temporary file root directory: ", temp_dir)
 log("info", "FFmpeg pre-processing filters: ", ffmpeg_audio_filters)
 
 --- Event handler for MPV's "shutdown" event.
--- This function is called when MPV is closing. It iterates through the
--- `files_to_cleanup_on_shutdown` table and attempts to remove each file
--- listed, using `safe_remove` to handle errors and logging.
--- After attempting cleanup, the `files_to_cleanup_on_shutdown` table is cleared.
+-- Leave per-run artifacts intact so Python-side cleanup can purge old runs.
 mp.register_event("shutdown", function()
-    log("info", "MPV shutdown event. Cleaning up temporary Parakeet files...")
-    if #files_to_cleanup_on_shutdown > 0 then
-        for _, filepath in ipairs(files_to_cleanup_on_shutdown) do
-            safe_remove(filepath, "Shutdown cleanup")
-        end
-        files_to_cleanup_on_shutdown = {} -- Clear the table after attempting cleanup
-    else
-        log("info", "No temporary files registered for cleanup.")
-    end
-    log("info", "Parakeet shutdown cleanup finished.")
+    log("info", "MPV shutdown event. Parakeet run artifacts remain available under the temp root.")
+    if attach_timer then attach_timer:kill(); attach_timer = nil end
+    log("info", "Parakeet shutdown handling finished.")
 end)

--- a/parakeet_transcribe.py
+++ b/parakeet_transcribe.py
@@ -644,7 +644,7 @@ def main():
         t3 = time.perf_counter()
         _log_event("postprocess_done", out_events=len(processed), postproc_s=round(t3 - t2, 3))
         _audit(segments, processed)
-        write_srt(processed, srt_path)
+        write_srt(processed, srt_path, diag_root=RUN_DIR)
         t4 = time.perf_counter()
         print(
             "TIMINGS  load={:.3f}s  asr={:.3f}s  post={:.3f}s  write={:.3f}s  total={:.3f}s".format(

--- a/parakeet_transcribe.py
+++ b/parakeet_transcribe.py
@@ -90,14 +90,21 @@ def _setup_logs():
 
     # Choose destination
     forced_file = os.environ.get("PARAKEET_LOG_FILE")
+    max_age_h = float(os.environ.get("PARAKEET_PURGE_MAX_AGE_HOURS", "24"))
     if forced_file:
         LOG_PATH = forced_file
         RUN_DIR = os.path.dirname(LOG_PATH) or tempfile.gettempdir()
+        root = os.environ.get("PARAKEET_LOG_ROOT")
+        if not root:
+            parent = os.path.dirname(RUN_DIR)
+            if parent and parent != RUN_DIR:
+                root = parent
+        if root:
+            _purge_old_runs(root, max_age_h)
     else:
         root = os.environ.get("PARAKEET_LOG_ROOT") or os.path.join(tempfile.gettempdir(), "parakeet_runs")
         _safe_makedirs(root)
         # Only purge *old* runs, not everything, to avoid races.
-        max_age_h = float(os.environ.get("PARAKEET_PURGE_MAX_AGE_HOURS", "24"))
         _purge_old_runs(root, max_age_h)
         stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
         RUN_DIR = os.path.join(root, f"{stamp}_{RUN_ID[:8]}")

--- a/srt_utils.py
+++ b/srt_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-from typing import List, Dict, Any, Tuple
+from typing import List, Dict, Any, Tuple, Optional
 import math, sys, os, time, re, csv, json
+from pathlib import Path
 from segmenter import segment_by_pause_and_phrase, shape_words_into_two_lines_balanced
 
 # ---------- tiny helpers ----------
@@ -83,7 +84,14 @@ def _fmt_ms(total_ms: int) -> str:
 def format_start_ms(t: float) -> str: return _fmt_ms(_ms_ceil (t))
 def format_end_ms  (t: float) -> str: return _fmt_ms(_ms_floor(t))
 
-def _write_diag_sidecar(events, out_path):
+def _ensure_dir(path: Path) -> None:
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        pass
+
+
+def _write_diag_sidecar(events, out_path, diag_root: Optional[str] = None):
     rows = []
     for i, ev in enumerate(events, 1):
         d = ev.get("_dbg", {}) or {}
@@ -106,19 +114,25 @@ def _write_diag_sidecar(events, out_path):
             "gave_to_left_ms": d.get("gave_to_left_ms", 0),
             "final_gap_fence_ms": d.get("final_gap_fence_ms", 0),
         })
-    base = out_path
-    with open(base + ".diag.csv", "w", newline="", encoding="utf-8") as f:
+    base_path = Path(out_path)
+    if diag_root:
+        base_dir = Path(diag_root)
+    else:
+        base_dir = base_path.parent
+    _ensure_dir(base_dir)
+    base = base_dir / base_path.stem
+    with open(str(base) + ".diag.csv", "w", newline="", encoding="utf-8") as f:
         w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
         w.writeheader(); w.writerows(rows)
-    with open(base + ".diag.json", "w", encoding="utf-8") as f:
+    with open(str(base) + ".diag.json", "w", encoding="utf-8") as f:
         json.dump(rows, f, ensure_ascii=False, indent=2)
 
-def write_srt(events: List[Dict[str,Any]], out_path: str) -> None:
+def write_srt(events: List[Dict[str,Any]], out_path: str, diag_root: Optional[str] = None) -> None:
     with open(out_path, "w", encoding="utf-8") as f:
         for i, ev in enumerate(events, 1):
             f.write(f"{i}\n{format_start_ms(ev['start'])} --> {format_end_ms(ev['end'])}\n{(ev['text'] or '').strip()}\n\n")
     try:
-        _write_diag_sidecar(events, out_path)
+        _write_diag_sidecar(events, out_path, diag_root)
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
- update both MPV Lua scripts to write temporary audio into the parakeet_runs temp directory
- ensure SRT diagnostic sidecars are saved alongside the run.log/run.jsonl files inside the parakeet_runs run folder
- pass the run directory to SRT writing so CSV/JSON diagnostics land in the centralized temp location

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cac2d77f38832c9376e450db55bc7c