### PR TITLE
Support run diagnostics directory

### DIFF
--- a/parakeet_caption.lua
+++ b/parakeet_caption.lua
@@ -6,9 +6,9 @@
 -- - SRT loading now attempted immediately after Python script finishes.
 -- - Temporary file cleanup moved to MPV shutdown event.
 
-local mp = require 'mp'
-local utils = require 'mp.utils'
-local msg   = mp.msg
+local mp   = require 'mp'
+local utils= require 'mp.utils'
+local msg  = mp.msg
 
 local osd_duration_default = 3 -- seconds
 
@@ -86,23 +86,35 @@ local function _rand8()
   local n = math.random(0, 0xffffffff)
   return string.format("%08x", n)
 end
-local function _ensure_dir(p)
-  if utils.file_info(p) then return end
+local function ensure_dir_quiet(dir)
+  if utils.file_info(dir) then return true end
   local is_win = package.config:sub(1,1) == '\\'
-  local args
-  if is_win then
-    args = {"cmd", "/C", "mkdir", p}
+  local args = is_win and {"cmd", "/D", "/C", "mkdir", dir} or {"mkdir", "-p", dir}
+  local res = utils.subprocess({ args = args, playback_only = false })
+  if (res and res.status == 0) or utils.file_info(dir) then
+    msg.info("[parakeet_mpv] Ensured directory: " .. dir)
+    return true
   else
-    args = {"mkdir", "-p", p}
+    msg.warn(string.format("[parakeet_mpv] mkdir failed (status=%s): %s", tostring(res and res.status), dir))
+    return false
   end
-  utils.subprocess({ args = args, cancellable = false })
 end
+
+local function _prefer_pythonw(p)
+  if package.config:sub(1,1) ~= '\\' then return p end
+  if not p or p == "" then return p end
+  local alt = p:gsub("[Pp]ython.exe$", "pythonw.exe")
+  if alt ~= p and utils.file_info(alt) then return alt end
+  return p
+end
+
+python_exe = _prefer_pythonw(python_exe)
 local temp_root = _tmp_root()
-_ensure_dir(temp_root)
+ensure_dir_quiet(temp_root)
 -- Note: Python will also purge old run dirs (>24h) on startup (see _setup_logs).
 -- That already handles lifetime management.
 local run_dir = utils.join_path(temp_root, os.date("%Y%m%d-%H%M%S") .. "_" .. _rand8())
-_ensure_dir(run_dir)
+ensure_dir_quiet(run_dir)
 local temp_dir = run_dir
 
 -- Keybindings for different transcription modes.
@@ -190,33 +202,6 @@ end
 local function to_str_safe(val)
     if val == nil then return "nil" end
     return tostring(val)
-end
-
--- Ensure the temporary directory exists. Attempt to create it if it doesn't.
--- This block checks for the existence of `temp_dir`. If not found, it tries
--- to create it using OS-specific commands. Warnings are logged if creation fails
--- or if `temp_dir` points to a root drive on Windows (which `mkdir` cannot create).
-if not utils.file_info(temp_dir) then
-    mp.msg.warn("[parakeet_mpv] Temporary directory does not exist: " .. temp_dir)
-    local mkdir_cmd
-    if package.config:sub(1,1) == '\\' then -- Windows OS
-        if temp_dir:match("^[A-Za-z]:$") then -- Check if it's a root drive like C:
-            mp.msg.warn("[parakeet_mpv] Cannot 'mkdir' a root drive like '" .. temp_dir .. "'. Please ensure it's accessible and not a root drive itself for mkdir.")
-        else
-            -- For Windows, use cmd /C to handle spaces in paths correctly for mkdir
-            mkdir_cmd = string.format('cmd /C "if not exist "%s" mkdir "%s""', temp_dir:gsub("/", "\\"), temp_dir:gsub("/", "\\"))
-            local _, err_code = os.execute(mkdir_cmd)
-            if err_code == 0 then
-                mp.msg.info("[parakeet_mpv] Attempted to create temp directory: " .. temp_dir)
-            else
-                mp.msg.warn("[parakeet_mpv] Failed to create temp directory. Exit Code: " .. to_str_safe(err_code))
-            end
-        end
-    else -- Linux/macOS
-        mkdir_cmd = string.format('mkdir -p "%s"', temp_dir)
-        os.execute(mkdir_cmd)
-        mp.msg.info("[parakeet_mpv] Attempted to create temp directory: " .. temp_dir)
-    end
 end
 
 --- Internal logging function for the script.

--- a/parakeet_caption.lua
+++ b/parakeet_caption.lua
@@ -70,6 +70,11 @@ local weights_dir = _first_nonempty(
 local ffmpeg_path  = os.getenv("FFMPEG")  or "ffmpeg"
 local ffprobe_path = os.getenv("FFPROBE") or "ffprobe"
 
+-- Small OS helpers
+local function is_windows() return package.config:sub(1,1) == '\\' end
+local function to_native(p) return is_windows() and (p:gsub("/", "\\")) or p end
+local function is_cmd_name(p) return p and p ~= "" and not p:find("[/\\]") and not p:match("^[A-Za-z]:") end
+
 -- Directory for storing temporary audio files.
 -- Always use system temp → <temp>/parakeet_runs/<stamp>_<id>
 local function _tmp_root()
@@ -87,17 +92,21 @@ local function _rand8()
   return string.format("%08x", n)
 end
 local function ensure_dir_quiet(dir)
-  if utils.file_info(dir) then return true end
-  local is_win = package.config:sub(1,1) == '\\'
-  local args = is_win and {"cmd", "/D", "/C", "mkdir", dir} or {"mkdir", "-p", dir}
-  local res = utils.subprocess({ args = args, playback_only = false })
-  if (res and res.status == 0) or utils.file_info(dir) then
+  dir = to_native(dir)
+  local st = utils.file_info(dir)
+  if st and st.is_dir then return true end
+  local args = is_windows() and {"cmd", "/D", "/C", "mkdir", dir} or {"mkdir", "-p", dir}
+  local res  = utils.subprocess({ args = args, playback_only = false, capture_stdout = true, capture_stderr = true })
+  -- Recheck after attempt (handles mkdir creating parents)
+  st = utils.file_info(dir)
+  if st and st.is_dir then
     msg.info("[parakeet_mpv] Ensured directory: " .. dir)
     return true
-  else
-    msg.warn(string.format("[parakeet_mpv] mkdir failed (status=%s): %s", tostring(res and res.status), dir))
-    return false
   end
+  msg.warn(string.format("[parakeet_mpv] mkdir failed (rc=%s): %s%s%s",
+          tostring(res and res.status), dir,
+          res and res.stderr and " | stderr: " or "", res and (res.stderr or "") or ""))
+  return false
 end
 
 local function _prefer_pythonw(p)
@@ -108,12 +117,29 @@ local function _prefer_pythonw(p)
   return p
 end
 
-python_exe = _prefer_pythonw(python_exe)
+-- Resolve python from PATH when user supplied just "python"
+local function resolve_on_path(cmd)
+  if not is_cmd_name(cmd) then return nil end
+  local which = is_windows() and {"where", cmd} or {"which", cmd}
+  local r = utils.subprocess({ args = which, playback_only = false, capture_stdout = true })
+  if r and r.status == 0 and r.stdout and #r.stdout > 0 then
+    local first = r.stdout:gsub("\r",""):gsub("\n+$",""):match("^[^\r\n]+")
+    return first
+  end
+  return nil
+end
+
+-- Prefer pythonw on Windows; allow PATH command names
+do
+  local resolved = resolve_on_path(python_exe)
+  if resolved then python_exe = resolved end
+  python_exe = _prefer_pythonw(python_exe)
+end
 local temp_root = _tmp_root()
 ensure_dir_quiet(temp_root)
 -- Note: Python will also purge old run dirs (>24h) on startup (see _setup_logs).
 -- That already handles lifetime management.
-local run_dir = utils.join_path(temp_root, os.date("%Y%m%d-%H%M%S") .. "_" .. _rand8())
+local run_dir = to_native(utils.join_path(temp_root, os.date("%Y%m%d-%H%M%S") .. "_" .. _rand8()))
 ensure_dir_quiet(run_dir)
 local temp_dir = run_dir
 
@@ -448,10 +474,9 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
         transcription_in_progress = false
     end
     -- Step 0: Validations
-    if not utils.file_info(python_exe) then
-        log("error", "Python executable not found: ", python_exe)
-        abort()
-        return
+    if (not is_cmd_name(python_exe)) and (not utils.file_info(python_exe)) then
+        log("error", "Python executable not found on disk: ", python_exe)
+        abort(); return
     end
     if not utils.file_info(parakeet_script_path) then
         log("error", "Parakeet Python script not found: '", parakeet_script_path, "'")
@@ -469,9 +494,11 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
         return
     end
     if not utils.file_info(temp_dir) or not utils.file_info(temp_dir).is_dir then
-        log("error", "Temporary directory '", temp_dir, "' does not exist or is not a directory.")
-        abort()
-        return
+        ensure_dir_quiet(temp_dir)
+        if not (utils.file_info(temp_dir) and utils.file_info(temp_dir).is_dir) then
+            log("error", "Temporary directory '", temp_dir, "' does not exist or is not a directory.")
+            abort(); return
+        end
     end
 
     local current_media_path = mp.get_property_native("path")
@@ -708,10 +735,9 @@ local function run_isolate_then_asr(model)
         transcription_in_progress = false
     end
 
-    if not utils.file_info(python_exe) then
-        log("error", "Python executable not found: ", python_exe)
-        abort()
-        return
+    if (not is_cmd_name(python_exe)) and (not utils.file_info(python_exe)) then
+        log("error", "Python executable not found on disk: ", python_exe)
+        abort(); return
     end
     if not utils.file_info(parakeet_script_path) then
         log("error", "Parakeet Python script not found: '", parakeet_script_path, "'")
@@ -724,9 +750,11 @@ local function run_isolate_then_asr(model)
         return
     end
     if not utils.file_info(temp_dir) or not utils.file_info(temp_dir).is_dir then
-        log("error", "Temporary directory '", temp_dir, "' does not exist or is not a directory.")
-        abort()
-        return
+        ensure_dir_quiet(temp_dir)
+        if not (utils.file_info(temp_dir) and utils.file_info(temp_dir).is_dir) then
+            log("error", "Temporary directory '", temp_dir, "' does not exist or is not a directory.")
+            abort(); return
+        end
     end
 
     local current_media_path = mp.get_property_native("path")

--- a/parakeet_caption.lua
+++ b/parakeet_caption.lua
@@ -16,50 +16,77 @@ local osd_duration_default = 3 -- seconds
 -- this script intentionally avoids forcing ASS overrides.
 
 -- ########## Configuration ##########
--- These paths should be configured by the user.
+-- Prefer environment variables; fall back to discoverable defaults.
+-- This makes fresh installs work without editing the file.
 
---- Path to the Python executable within the virtual environment.
+--- Path to the Python executable (env: PARAKEET_PYTHON_EXE). Falls back to 'python' on PATH.
 -- This should be the full path to the `python.exe` (Windows) or `python` (Linux/macOS)
 -- located inside the `Scripts` or `bin` directory of your Python virtual environment
 -- where Riva Canary ASR / Parakeet is installed.
 -- @type string
 -- @example "C:/venvs/nemo_mpv_py312/Scripts/python.exe"
 -- @example "/home/user/venvs/nemo_mpv_py312/bin/python"
-local python_exe = "C:/venvs/nemo_mpv_py312/Scripts/python.exe"
+local python_exe = os.getenv("PARAKEET_PYTHON_EXE") or "python"
 
---- Path to the parakeet_transcribe.py script.
--- This is the full path to the Python script responsible for performing the audio transcription.
--- @type string
--- @example "C:/Parakeet_Caption/parakeet_transcribe.py"
--- @example "/home/user/Parakeet_Caption/parakeet_transcribe.py"
-local parakeet_script_path = "C:/Parakeet_Caption/parakeet_transcribe.py"
+--- Path to the parakeet_transcribe.py script (env: PARAKEET_SCRIPT_PATH).
+local function _script_dir()
+  local src = debug.getinfo(1, "S").source or ""
+  local dir = src:match("^@(.*)[/\\]") or ""
+  if dir == "" then
+    local cwd = utils.getcwd()
+    return cwd or "."
+  end
+  return dir
+end
+local parakeet_script_path = os.getenv("PARAKEET_SCRIPT_PATH") or (utils.join_path(_script_dir(), "parakeet_transcribe.py"))
 
 --- Path to the FFmpeg executable.
--- Can be set to just "ffmpeg" if the directory containing ffmpeg.exe (Windows) or ffmpeg (Linux/macOS)
--- is included in the system's PATH environment variable. Otherwise, provide the full path.
--- FFmpeg is used for extracting and pre-processing audio from the media file.
--- @type string
--- @example "ffmpeg"
--- @example "C:/ffmpeg/bin/ffmpeg.exe"
+-- (env: FFMPEG). Default to 'ffmpeg' on PATH.
 local ffmpeg_path = "ffmpeg"
+if os.getenv("FFMPEG") and os.getenv("FFMPEG") ~= "" then ffmpeg_path = os.getenv("FFMPEG") end
 
 --- Path to the FFprobe executable.
--- Can be set to just "ffprobe" if the directory containing ffprobe.exe (Windows) or ffprobe (Linux/macOS)
--- is included in the system's PATH environment variable. Otherwise, provide the full path.
--- FFprobe is used to gather information about audio streams in the media file.
--- @type string
--- @example "ffprobe"
--- @example "C:/ffmpeg/bin/ffprobe.exe"
+-- (env: FFPROBE). Default to 'ffprobe' on PATH.
 local ffprobe_path = "ffprobe"
+if os.getenv("FFPROBE") and os.getenv("FFPROBE") ~= "" then ffprobe_path = os.getenv("FFPROBE") end
 
 --- Directory for storing temporary audio files.
--- This directory must exist and be writable by MPV and the user running MPV.
--- Temporary WAV files extracted from the media will be stored here before transcription.
--- These files are cleaned up when MPV shuts down.
--- @type string
--- @example "C:/temp_audio_mpv"
--- @example "/tmp/mpv_parakeet_audio"
-local temp_dir = "C:/temp"
+-- We create one per-run directory under %TEMP%/parakeet_runs to match Python logs.
+local function _tmp_root()
+  local t = os.getenv("PARAKEET_LOG_ROOT")
+  if not t or t == "" then
+    t = os.getenv("TEMP") or os.getenv("TMPDIR") or "/tmp"
+  end
+  return utils.join_path(t, "parakeet_runs")
+end
+local _rand_seeded = false
+local function _rand8()
+  if not _rand_seeded then
+    local jitter = math.floor((mp.get_time() or 0) * 1000)
+    math.randomseed(os.time() + jitter)
+    _rand_seeded = true
+  end
+  local n = math.random(0, 0xffffffff)
+  return string.format("%08x", n)
+end
+local function _ensure_dir(p)
+  if utils.file_info(p) then return end
+  local is_win = package.config:sub(1,1) == '\\'
+  local args
+  if is_win then
+    args = {"cmd", "/C", "mkdir", p}
+  else
+    args = {"mkdir", "-p", p}
+  end
+  utils.subprocess({ args = args, cancellable = false })
+end
+local temp_root = _tmp_root()
+_ensure_dir(temp_root)
+-- Note: Python will also purge old run dirs (>24h) on startup (see _setup_logs).
+-- That already handles lifetime management.
+local run_dir = utils.join_path(temp_root, os.date("%Y%m%d-%H%M%S") .. "_" .. _rand8())
+_ensure_dir(run_dir)
+local temp_dir = run_dir
 
 -- Keybindings for different transcription modes.
 local key_binding_default = "Alt+4"             -- Standard transcription (no FFmpeg preprocessing, default Python precision)
@@ -630,6 +657,9 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
         srt_output_path,       -- Output SRT file path
         "--audio_start_offset", tostring(audio_stream_offset_seconds) -- Pass the determined start offset
     }
+    -- Make Python use the same run directory for logs & diagnostics
+    table.insert(python_command_args, "--run_dir"); table.insert(python_command_args, run_dir)
+    table.insert(python_command_args, "--diag_dir"); table.insert(python_command_args, run_dir)
     if force_python_float32_flag then
         table.insert(python_command_args, "--force_float32")
     end
@@ -657,6 +687,12 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
       playback_only = false,
       capture_stdout = false,
       capture_stderr = false,
+      env = {
+        -- keep Python bootstrap behavior consistent with our run dir
+        ["PARAKEET_LOG_ROOT"] = temp_root,
+        ["PARAKEET_RUN_DIR"]  = run_dir,
+        ["PARAKEET_DIAG_DIR"] = run_dir,
+      }
     }, function(success, res, err)
       local rc = (res and res.status) or -1
       if not success or rc ~= 0 then
@@ -839,6 +875,8 @@ local function run_isolate_then_asr(model)
         python_exe, parakeet_script_path, temp_vocals_16k, srt_output_path,
         "--audio_start_offset", tostring(audio_offset_seconds)
     }
+    table.insert(parakeet_args, "--run_dir"); table.insert(parakeet_args, run_dir)
+    table.insert(parakeet_args, "--diag_dir"); table.insert(parakeet_args, run_dir)
     for _,v in ipairs(seg_args) do table.insert(parakeet_args, v) end
     local fps = mp.get_property_native("container-fps") or mp.get_property_native("fps") or 24
     table.insert(parakeet_args, "--fps=" .. string.format("%.3f", fps))
@@ -848,6 +886,11 @@ local function run_isolate_then_asr(model)
       playback_only = false,
       capture_stdout = false,
       capture_stderr = false,
+      env = {
+        ["PARAKEET_LOG_ROOT"] = temp_root,
+        ["PARAKEET_RUN_DIR"]  = run_dir,
+        ["PARAKEET_DIAG_DIR"] = run_dir,
+      }
     }
     local initial_stat = _stat(srt_output_path)
     attach_when_ready(srt_output_path, {

--- a/parakeet_caption.lua
+++ b/parakeet_caption.lua
@@ -19,16 +19,20 @@ local osd_duration_default = 3 -- seconds
 -- Prefer environment variables; fall back to discoverable defaults.
 -- This makes fresh installs work without editing the file.
 
---- Path to the Python executable (env: PARAKEET_PYTHON_EXE). Falls back to 'python' on PATH.
--- This should be the full path to the `python.exe` (Windows) or `python` (Linux/macOS)
--- located inside the `Scripts` or `bin` directory of your Python virtual environment
--- where Riva Canary ASR / Parakeet is installed.
--- @type string
--- @example "C:/venvs/nemo_mpv_py312/Scripts/python.exe"
--- @example "/home/user/venvs/nemo_mpv_py312/bin/python"
-local python_exe = os.getenv("PARAKEET_PYTHON_EXE") or "python"
+-- ─────────────────────────────────────────────────────────────────────────────
+-- User-configurable overrides (leave "" to skip and use ENV/auto)
+--   • python_exe: point this to your venv’s python
+--   • script_path: absolute path to parakeet_transcribe.py
+--   • weights_dir: root folder of your model weights
+-- Edit just these 3 and you should be good on a new machine.
+-- ─────────────────────────────────────────────────────────────────────────────
+local OVERRIDE = {
+  python_exe = "",
+  script_path = "",
+  weights_dir = "",
+}
 
---- Path to the parakeet_transcribe.py script (env: PARAKEET_SCRIPT_PATH).
+-- Helpers
 local function _script_dir()
   local src = debug.getinfo(1, "S").source or ""
   local dir = src:match("^@(.*)[/\\]") or ""
@@ -38,25 +42,38 @@ local function _script_dir()
   end
   return dir
 end
-local parakeet_script_path = os.getenv("PARAKEET_SCRIPT_PATH") or (utils.join_path(_script_dir(), "parakeet_transcribe.py"))
 
---- Path to the FFmpeg executable.
--- (env: FFMPEG). Default to 'ffmpeg' on PATH.
-local ffmpeg_path = "ffmpeg"
-if os.getenv("FFMPEG") and os.getenv("FFMPEG") ~= "" then ffmpeg_path = os.getenv("FFMPEG") end
+local function _first_nonempty(a, b, c)
+  if a and a ~= "" then return a end
+  if b and b ~= "" then return b end
+  return c
+end
 
---- Path to the FFprobe executable.
--- (env: FFPROBE). Default to 'ffprobe' on PATH.
-local ffprobe_path = "ffprobe"
-if os.getenv("FFPROBE") and os.getenv("FFPROBE") ~= "" then ffprobe_path = os.getenv("FFPROBE") end
+-- Resolve python exe / script path / weights dir
+local python_exe = _first_nonempty(
+  OVERRIDE.python_exe,
+  os.getenv("PARAKEET_PYTHON_EXE"),
+  "python"
+)
+local parakeet_script_path = _first_nonempty(
+  OVERRIDE.script_path,
+  os.getenv("PARAKEET_SCRIPT_PATH"),
+  utils.join_path(_script_dir(), "parakeet_transcribe.py")
+)
+local weights_dir = _first_nonempty(
+  OVERRIDE.weights_dir,
+  os.getenv("PARAKEET_WEIGHTS_DIR"),
+  utils.join_path(_script_dir(), "weights")
+)
 
---- Directory for storing temporary audio files.
--- We create one per-run directory under %TEMP%/parakeet_runs to match Python logs.
+-- ffmpeg/ffprobe strictly from ENV (or fall back to PATH name)
+local ffmpeg_path  = os.getenv("FFMPEG")  or "ffmpeg"
+local ffprobe_path = os.getenv("FFPROBE") or "ffprobe"
+
+-- Directory for storing temporary audio files.
+-- Always use system temp → <temp>/parakeet_runs/<stamp>_<id>
 local function _tmp_root()
-  local t = os.getenv("PARAKEET_LOG_ROOT")
-  if not t or t == "" then
-    t = os.getenv("TEMP") or os.getenv("TMPDIR") or "/tmp"
-  end
+  local t = os.getenv("TEMP") or os.getenv("TMPDIR") or "/tmp"
   return utils.join_path(t, "parakeet_runs")
 end
 local _rand_seeded = false
@@ -95,10 +112,6 @@ local key_binding_ffmpeg_preprocess = "Alt+6"   -- FFmpeg Preprocessing (default
 local key_binding_ffmpeg_py_float32 = "Alt+7" -- FFmpeg Preprocessing + Python Float32 Precision
 local key_binding_isolate_asr_fast = "Alt+8"   -- Vocal isolation + ASR (fast)
 local key_binding_isolate_asr_slow = "Alt+9"   -- Vocal isolation + ASR (high quality)
-
--- Root directory containing separation model weights.
--- Provide the full path so Python can locate the YAML and checkpoint files reliably.
-local weights_dir = "C:/Parakeet_Caption/weights"
 
 -- === Separation models you selected in A/B ===
 local sep_fast = {
@@ -686,13 +699,7 @@ local function do_transcription_core(force_python_float32_flag, apply_ffmpeg_fil
       args = python_command_args,
       playback_only = false,
       capture_stdout = false,
-      capture_stderr = false,
-      env = {
-        -- keep Python bootstrap behavior consistent with our run dir
-        ["PARAKEET_LOG_ROOT"] = temp_root,
-        ["PARAKEET_RUN_DIR"]  = run_dir,
-        ["PARAKEET_DIAG_DIR"] = run_dir,
-      }
+      capture_stderr = false
     }, function(success, res, err)
       local rc = (res and res.status) or -1
       if not success or rc ~= 0 then
@@ -885,12 +892,7 @@ local function run_isolate_then_asr(model)
       args = parakeet_args,
       playback_only = false,
       capture_stdout = false,
-      capture_stderr = false,
-      env = {
-        ["PARAKEET_LOG_ROOT"] = temp_root,
-        ["PARAKEET_RUN_DIR"]  = run_dir,
-        ["PARAKEET_DIAG_DIR"] = run_dir,
-      }
+      capture_stderr = false
     }
     local initial_stat = _stat(srt_output_path)
     attach_when_ready(srt_output_path, {

--- a/parakeet_transcribe.py
+++ b/parakeet_transcribe.py
@@ -99,9 +99,15 @@ def _setup_logs():
         # Only purge *old* runs, not everything, to avoid races.
         max_age_h = float(os.environ.get("PARAKEET_PURGE_MAX_AGE_HOURS", "24"))
         _purge_old_runs(root, max_age_h)
-        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-        RUN_DIR = os.path.join(root, f"{stamp}_{RUN_ID[:8]}")
-        _safe_makedirs(RUN_DIR)
+        # If the caller (Lua/mpv) already created a run dir, prefer that.
+        pre_run = os.environ.get("PARAKEET_RUN_DIR")
+        if pre_run:
+            RUN_DIR = pre_run
+            _safe_makedirs(RUN_DIR)
+        else:
+            stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+            RUN_DIR = os.path.join(root, f"{stamp}_{RUN_ID[:8]}")
+            _safe_makedirs(RUN_DIR)
         LOG_PATH = os.path.join(RUN_DIR, "run.log")
 
     JSONL_PATH = os.path.join(RUN_DIR, "run.jsonl")
@@ -394,8 +400,15 @@ def main():
                         help="Max duration for a packed 2-line block")
     parser.add_argument("--max_merge_gap_ms", type=int, default=360,
                         help="Max gap for orphan merges/borrowing")
+    parser.add_argument("--run_dir", type=str, default=None,
+                        help="Existing run directory to write logs/sidecars (overrides generated RUN_DIR).")
+    parser.add_argument("--diag_dir", type=str, default=None,
+                        help="Directory for .diag.csv/.diag.json (defaults to RUN_DIR).")
     args = parser.parse_args()
 
+    # Allow CLI flags to prime environment for logging bootstrap
+    if args.run_dir:
+        os.environ["PARAKEET_RUN_DIR"] = args.run_dir
     _setup_logs()
 
     audio_path = args.audio_file_path
@@ -644,7 +657,9 @@ def main():
         t3 = time.perf_counter()
         _log_event("postprocess_done", out_events=len(processed), postproc_s=round(t3 - t2, 3))
         _audit(segments, processed)
-        write_srt(processed, srt_path)
+        # Prefer explicit diag_dir, else fall back to current RUN_DIR
+        diag_dir = args.diag_dir or os.environ.get("PARAKEET_DIAG_DIR") or RUN_DIR
+        write_srt(processed, srt_path, diag_dir=diag_dir)
         t4 = time.perf_counter()
         print(
             "TIMINGS  load={:.3f}s  asr={:.3f}s  post={:.3f}s  write={:.3f}s  total={:.3f}s".format(

--- a/srt_utils.py
+++ b/srt_utils.py
@@ -83,7 +83,7 @@ def _fmt_ms(total_ms: int) -> str:
 def format_start_ms(t: float) -> str: return _fmt_ms(_ms_ceil (t))
 def format_end_ms  (t: float) -> str: return _fmt_ms(_ms_floor(t))
 
-def _write_diag_sidecar(events, out_path):
+def _write_diag_sidecar(events, out_path, diag_dir: str | None = None):
     rows = []
     for i, ev in enumerate(events, 1):
         d = ev.get("_dbg", {}) or {}
@@ -106,19 +106,25 @@ def _write_diag_sidecar(events, out_path):
             "gave_to_left_ms": d.get("gave_to_left_ms", 0),
             "final_gap_fence_ms": d.get("final_gap_fence_ms", 0),
         })
-    base = out_path
+    # If a diagnostics directory is provided, write the sidecars there,
+    # using the SRT basename (without extension) to keep filenames readable.
+    if diag_dir:
+        os.makedirs(diag_dir, exist_ok=True)
+        base = os.path.join(diag_dir, os.path.splitext(os.path.basename(out_path))[0])
+    else:
+        base = out_path
     with open(base + ".diag.csv", "w", newline="", encoding="utf-8") as f:
         w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
         w.writeheader(); w.writerows(rows)
     with open(base + ".diag.json", "w", encoding="utf-8") as f:
         json.dump(rows, f, ensure_ascii=False, indent=2)
 
-def write_srt(events: List[Dict[str,Any]], out_path: str) -> None:
+def write_srt(events: List[Dict[str,Any]], out_path: str, diag_dir: str | None = None) -> None:
     with open(out_path, "w", encoding="utf-8") as f:
         for i, ev in enumerate(events, 1):
             f.write(f"{i}\n{format_start_ms(ev['start'])} --> {format_end_ms(ev['end'])}\n{(ev['text'] or '').strip()}\n\n")
     try:
-        _write_diag_sidecar(events, out_path)
+        _write_diag_sidecar(events, out_path, diag_dir)
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
- allow SRT sidecar writers to target an explicit diagnostics directory
- let parakeet_transcribe reuse externally-created run directories and expose --run_dir/--diag_dir arguments
- make the MPV Lua helper auto-create per-run working directories, source paths from environment variables, and pass run/diagnostic directories to Python

## Testing
- pytest

