### PR TITLE
Adjust MPV scripts to only force float32 when requested

### DIFF
--- a/parakeet_caption.lua
+++ b/parakeet_caption.lua
@@ -165,7 +165,7 @@ local sep_slow = {
 }
 
 -- Word segmenter knobs (what you used in batch)
-local seg_args = { "--segmenter","word","--max_words","12","--max_duration","6.0","--pause","0.6","--force_float32" }
+local seg_args = { "--segmenter","word","--max_words","12","--max_duration","6.0","--pause","0.6" }
 
 --- FFmpeg audio filter chain for pre-processing mode.
 -- This string defines the audio filters FFmpeg will apply when the

--- a/parakeet_caption_for_JellyfinMpvShim.lua
+++ b/parakeet_caption_for_JellyfinMpvShim.lua
@@ -84,7 +84,7 @@ local sep_slow = {
 }
 
 -- Word segmenter knobs (what you used in batch)
-local seg_args = { "--segmenter","word","--max_words","12","--max_duration","6.0","--pause","0.6","--force_float32" }
+local seg_args = { "--segmenter","word","--max_words","12","--max_duration","6.0","--pause","0.6" }
 
 --- FFmpeg audio filter chain for pre-processing mode.
 -- This string defines the audio filters FFmpeg will apply when the


### PR DESCRIPTION
## Summary
- remove the default `--force_float32` segmenter argument in the MPV Lua scripts
- rely on the existing float32-specific keybindings to append the flag when desired so default runs use mixed precision

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cea260dcc8832c8acf3cbaaed02387